### PR TITLE
Make #createSurface on RSAthensMorph invalidate the canvas

### DIFF
--- a/src/Roassal/RSAthensMorph.class.st
+++ b/src/Roassal/RSAthensMorph.class.st
@@ -63,7 +63,8 @@ RSAthensMorph >> checkSession [
 { #category : 'surface management' }
 RSAthensMorph >> createSurface [
 	surface := AthensCairoSurface extent: self extent asIntegerPoint.
-	session := Smalltalk session
+	session := Smalltalk session.
+	roassalCanvas ifNotNil: [ roassalCanvas invalidate ]
 ]
 
 { #category : 'drawing' }


### PR DESCRIPTION
This pull request makes `#createSurface` on RSAthensMorph invalidate the canvas (to fix issue #51, “Roassal ‘Demo’ window is blank after reopening image”).