### PR TITLE
Make RSAthensMorph apply the world renderer canvas scale factor

### DIFF
--- a/src/Roassal/RSAthensMorph.class.st
+++ b/src/Roassal/RSAthensMorph.class.st
@@ -73,7 +73,7 @@ RSAthensMorph >> drawOn: aCanvas [
 	isDrawing := true.
 	[
 		self checkSession.
-		self recreateSurfaceIfNecessary: OSWorldRenderer canvasScaleFactor.
+		self recreateSurfaceIfNecessary: aCanvas scale.
 		aCanvas
 			fillRectangle: self bounds
 			fillStyle: roassalCanvas color

--- a/src/Roassal/RSAthensMorph.class.st
+++ b/src/Roassal/RSAthensMorph.class.st
@@ -84,8 +84,10 @@ RSAthensMorph >> drawOn: aCanvas [
 		surface hasBeenFreed
 			ifTrue: [ self createSurface ].
 		[ aCanvas
-			translucentFormSet: (FormSet extent: self extent asIntegerPoint depth: 32 forms: { surface asForm })
-			at: self bounds origin asIntegerPoint ]
+			formSet: (FormSet extent: self extent asIntegerPoint depth: 32 forms: { surface asForm })
+			at: self bounds origin asIntegerPoint
+			sourceRect: (0 @ 0 extent: surface extent)
+			rule: Form blendAlphaScaled ]
 		on: Exception
 		do: [ :ex | ex traceCr ]
 	] ensure: [ isDrawing := false ]

--- a/src/Roassal/RSAthensMorph.class.st
+++ b/src/Roassal/RSAthensMorph.class.st
@@ -8,6 +8,7 @@ Class {
 	#instVars : [
 		'renderer',
 		'session',
+		'surfaceScale',
 		'surface',
 		'isDrawing',
 		'roassalCanvas',
@@ -60,7 +61,7 @@ RSAthensMorph >> checkSession [
 
 { #category : #'surface management' }
 RSAthensMorph >> createSurface [
-	surface := AthensCairoSurface extent: self extent asIntegerPoint.
+	surface := AthensCairoSurface extent: self extent asIntegerPoint * surfaceScale.
 	session := Smalltalk session.
 	roassalCanvas ifNotNil: [ roassalCanvas invalidate ]
 ]
@@ -72,7 +73,7 @@ RSAthensMorph >> drawOn: aCanvas [
 	isDrawing := true.
 	[
 		self checkSession.
-		self recreateSurfaceIfNecessary.
+		self recreateSurfaceIfNecessary: OSWorldRenderer canvasScaleFactor.
 		aCanvas
 			fillRectangle: self bounds
 			fillStyle: roassalCanvas color
@@ -83,10 +84,8 @@ RSAthensMorph >> drawOn: aCanvas [
 		surface hasBeenFreed
 			ifTrue: [ self createSurface ].
 		[ aCanvas
-			image: surface asForm
-			at: self bounds origin asIntegerPoint
-			sourceRect: (0 @ 0 extent: surface extent)
-			rule: 34 ]
+			translucentFormSet: (FormSet extent: self extent asIntegerPoint depth: 32 forms: { surface asForm })
+			at: self bounds origin asIntegerPoint ]
 		on: Exception
 		do: [ :ex | ex traceCr ]
 	] ensure: [ isDrawing := false ]
@@ -118,7 +117,8 @@ RSAthensMorph >> drawShapes [
 	surface drawDuring: [ :athensCanvas |
 		renderer
 			surface: surface;
-			canvas: athensCanvas.
+			canvas: athensCanvas;
+			scale: surfaceScale.
 		roassalCanvas accept: renderer.
 	]
 ]
@@ -138,7 +138,7 @@ RSAthensMorph >> fullDrawOnAthensCanvas: aCanvas [
 	isDrawing := true.
 	[
 		self checkSession.
-		self recreateSurfaceIfNecessary.
+		self recreateSurfaceIfNecessary: 1.
 
 		aCanvas setPaint: roassalCanvas color.
 		aCanvas drawShape: (bounds translateBy: bounds origin negated).
@@ -217,6 +217,7 @@ RSAthensMorph >> hasFocus [
 RSAthensMorph >> initialize [
 	super initialize.
 	self eventProcessor: RSEventProcessor new.
+	surfaceScale := 0.
 	self createSurface.
 	session := Smalltalk session.
 	isDrawing := false
@@ -293,10 +294,11 @@ RSAthensMorph >> mouseWheel: evt [
 ]
 
 { #category : #'session management' }
-RSAthensMorph >> recreateSurfaceIfNecessary [
+RSAthensMorph >> recreateSurfaceIfNecessary: scale [
 	surface
-		ifNotNil: [ self extent asIntegerPoint ~= surface extent
-				ifTrue: [ self createSurface.
+		ifNotNil: [ (surfaceScale ~= scale or: [ self extent asIntegerPoint * surfaceScale ~= surface extent ])
+				ifTrue: [ surfaceScale := scale.
+					self createSurface.
 					roassalCanvas extent: self extent ] ]
 ]
 

--- a/src/Roassal/RSAthensRenderer.class.st
+++ b/src/Roassal/RSAthensRenderer.class.st
@@ -23,6 +23,7 @@ Class {
 		'showRectangles',
 		'originMatrix',
 		'surface',
+		'scale',
 		'dirtyRectangle'
 	],
 	#category : 'Roassal-Rendering'
@@ -581,6 +582,32 @@ RSAthensRenderer >> paintFor: shape form: form [
 ]
 
 { #category : #'visiting - helpers' }
+RSAthensRenderer >> pathTransformLoadMatrix [
+
+	athensCanvas pathTransform loadAffineTransform:
+		(AthensAffineTransform new
+			x: matrix x * scale;
+			y: matrix y * scale;
+			sx: matrix sx * scale;
+			sy: matrix sy * scale;
+			shx: matrix shx * scale;
+			shy: matrix shy * scale;
+			yourself)
+]
+
+{ #category : #accessing }
+RSAthensRenderer >> scale [
+
+	^ scale
+]
+
+{ #category : #accessing }
+RSAthensRenderer >> scale: anObject [
+
+	scale := anObject
+]
+
+{ #category : #'visiting - helpers' }
 RSAthensRenderer >> showEncompassingRectangleForLineIfNecessary: line [
 	showRectangles ifFalse: [ ^ self ].
 	self drawShadowRectangle: line encompassingRectangle
@@ -630,7 +657,7 @@ RSAthensRenderer >> visitBorderIfNecessary: shape [
 RSAthensRenderer >> visitBoundingShape: shape [
 	self visitShapeIfNecessary: shape block: [
 		| path paint |
-		athensCanvas pathTransform loadAffineTransform: matrix.
+		self pathTransformLoadMatrix.
 		path := self getOrCreatePathOf: shape.
 		paint := shape paintOn: self.
 		paint ifNotNil: [
@@ -666,6 +693,7 @@ RSAthensRenderer >> visitCanvas: aRSCanvas [
 	athensCanvas setAA: aRSCanvas host antialiasing.
 	aRSCanvas camera accept: self.
 	transformeDirtyRectangle := self transform: dirtyRectangle.
+	athensCanvas pathTransform loadIdentity scaleBy: scale.
 	aRSCanvas shouldClearBackground ifTrue: [
 		self clearRectangle: transformeDirtyRectangle ].
 	modifiedDirtyRectangle := self inverseTransform: transformeDirtyRectangle.
@@ -674,14 +702,14 @@ RSAthensRenderer >> visitCanvas: aRSCanvas [
 	dirtyRectangle := transformeDirtyRectangle.
 	matrix loadIdentity.
 	originMatrix loadIdentity.
-	athensCanvas pathTransform loadIdentity.
+	athensCanvas pathTransform loadIdentity scaleBy: scale.
 	athensCanvas clipBy: transformeDirtyRectangle during: [
 		(aRSCanvas fixedShapes entriesAtRectangle: dirtyRectangle) do: [ :each | each accept: self ] ].
 	aRSCanvas resetDirtyRectangle.
 
 	aRSCanvas shouldShowDirtyRectangle ifFalse: [ ^ self ].
 
-	athensCanvas pathTransform loadIdentity.
+	athensCanvas pathTransform loadIdentity scaleBy: scale.
 	matrix loadIdentity.
 	originMatrix loadIdentity.
 	aRSCanvas camera accept: self.
@@ -718,7 +746,7 @@ RSAthensRenderer >> visitLabel: label [
 		| lbtranslation |
 		lbtranslation := label textExtents translationPoint asFloatPoint.
 		matrix translateBy: lbtranslation.
-		athensCanvas pathTransform loadAffineTransform: matrix.
+		self pathTransformLoadMatrix.
 		label hasBorder
 			ifTrue: [ self drawPathLabel: label ]
 			ifFalse: [ self drawSimpleLabel: label ].
@@ -752,7 +780,7 @@ RSAthensRenderer >> visitLabelDecoratorsIfNecessary: label [
 RSAthensRenderer >> visitLine: line [
 	| path paint |
 	(line intersects: dirtyRectangle) ifFalse: [ ^ self ].
-	athensCanvas pathTransform loadAffineTransform: matrix.
+	self pathTransformLoadMatrix.
 	path := self getOrCreatePathOf: line.
 	paint := line paintOn: self.
 


### PR DESCRIPTION
This pull request extends RSAthensRenderer to support scaling, and uses that in RSAthensMorph to apply the canvas scale factor (which was introduced in [Pharo pull request #15647](https://github.com/pharo-project/pharo/pull/15647)).

The following screenshot compares the morph opened by RSChartExample’s #example03Plot in images without and with these changes (on a ‘Retina display’ with the canvas scale factor in each set to 2):

<img width="1048" src="https://github.com/pharo-graphics/Roassal/assets/1611248/b39336e9-860a-4a9d-be77-55ffe81345db">

In the image on the left, the Roassal shapes are drawn at scale 1 and then the surface form is scaled up, while in the image on the right, the Roassal shapes are drawn directly at scale 2, resulting in better detail in the label character glyphs and lines on the chart (click the screenshot to zoom in).

Note that the changes to RSAthensMorph use messages that are only implemented in Pharo 12.