### PR TITLE
Feature add relateive y axis label values

### DIFF
--- a/src/Roassal-Chart-Examples/RSHistogramExample.class.st
+++ b/src/Roassal-Chart-Examples/RSHistogramExample.class.st
@@ -202,6 +202,28 @@ RSHistogramExample >> example10Objects [
 	^ c canvas
 ]
 
+{ #category : 'examples' }
+RSHistogramExample >> example11RelativeYAxisLabels [
+
+	<script: 'self new example11RelativeYAxisLabels open'>
+	| data plot |
+	"The 0 element appears 14 times: 70%"
+	"The 2 element appears 2 times: 10%"
+	"The 10 element appears 4 times: 20%"
+	data := #( 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 2 10 10 10 10 ).
+	
+	plot := RSHistogramPlot new
+		x: data;
+		relativeVerticalTicks;
+		yourself.
+	"Add a label"
+	plot ylabel: 'Percent'.
+
+	plot yTicksRangeMax: 100 numberOfTicks: 6.
+
+	^ plot
+]
+
 { #category : 'computing' }
 RSHistogramExample >> normal: x mean: mean stdDev: std [
 	^ (-0.5 * Float twoPi log - std log -

--- a/src/Roassal-Chart/RSHistogramPlot.class.st
+++ b/src/Roassal-Chart/RSHistogramPlot.class.st
@@ -39,7 +39,8 @@ Class {
 		'x',
 		'bins',
 		'bars',
-		'binningStrategy'
+		'binningStrategy',
+		'isRelativeVerticalTicks'
 	],
 	#category : 'Roassal-Chart-Core',
 	#package : 'Roassal-Chart',
@@ -50,6 +51,13 @@ Class {
 RSHistogramPlot class >> of: aCollection on: aBloc [
 
 	^ self new collectDataOf: aCollection on: aBloc
+]
+
+{ #category : 'accessing' }
+RSHistogramPlot >> absoluteVerticalTicks [
+
+	isRelativeVerticalTicks := false.
+	self verticalTick labelConversion: [ :labelValue | labelValue ]
 ]
 
 { #category : 'accessing' }
@@ -139,8 +147,10 @@ RSHistogramPlot >> definedValuesY [
 
 { #category : 'initialization' }
 RSHistogramPlot >> initialize [
+
 	super initialize.
-	self binningStrategy: RSDefaultBinning new
+	self binningStrategy: RSDefaultBinning new.
+	isRelativeVerticalTicks := false
 ]
 
 { #category : 'accessing' }
@@ -179,6 +189,16 @@ RSHistogramPlot >> numberOfBins: aNumber [
 	self computeXYValues
 ]
 
+{ #category : 'accessing' }
+RSHistogramPlot >> relativeVerticalTicks [
+
+	"Adjust the vertical ticks label to show the relative labels. E.g. instead of showing that a bin appeared 17 times it will show 50%"
+
+	isRelativeVerticalTicks := true.
+	self verticalTick
+		labelConversion: [ :labelValue | (labelValue / x size) * 100 asInteger ]
+]
+
 { #category : 'rendering' }
 RSHistogramPlot >> renderIn: canvas [
 
@@ -208,4 +228,16 @@ RSHistogramPlot >> x [
 RSHistogramPlot >> x: aCollection [
 	x := aCollection sorted.
 	self computeXYValues
+]
+
+{ #category : 'accessing' }
+RSHistogramPlot >> yTicksRangeMax: max numberOfTicks: numberOfTicks [
+
+	| relativeMax |
+	relativeMax := isRelativeVerticalTicks
+		ifFalse: [ max ]
+		ifTrue: [ x size * (max / 100) ].
+
+	self verticalTick ticksData:
+		((0 to: relativeMax count: numberOfTicks) collect: #asInteger)
 ]


### PR DESCRIPTION
Added relative labels for the y axis for RSHistogram.
Pair programmed with @akevalion

For example, let's take this data as an example.

```st
#(0 0 0 0 0 0 0 0 0 0 0 0 0 0 2 2 10 10 10 10).
```
The number `0` appears 14 times which represents 70% of total occurrences.

In the default histogram, the one in the left, the number `14` appears as the label for the y-axis. When using the relative labels, the number `70` (the percentage) appears instead (the image in the right).

<img width="1400" alt="Capture d’écran 2024-03-05 à 16 20 15" src="https://github.com/pharo-graphics/Roassal/assets/33934979/d09fa09c-f311-4142-b4da-7516d17b3a55">


