### PR TITLE
Fix usage of removed dependentPackages

### DIFF
--- a/src/Roassal-Global-Tests/RSAdjacencyMatrixBuilderTest.class.st
+++ b/src/Roassal-Global-Tests/RSAdjacencyMatrixBuilderTest.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #RSAdjacencyMatrixBuilderTest,
-	#superclass : #RSTest,
+	#name : 'RSAdjacencyMatrixBuilderTest',
+	#superclass : 'RSTest',
 	#instVars : [
 		'empty',
 		'b'
 	],
-	#category : 'Roassal-Global-Tests-Examples'
+	#category : 'Roassal-Global-Tests-Examples',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSAdjacencyMatrixBuilderTest >> setUp [
 
 	super setUp.
@@ -19,14 +21,14 @@ RSAdjacencyMatrixBuilderTest >> setUp [
 	b connections: { 1 -> 2 . 1 -> 3 . 2 -> 4 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testBasic01 [
 
 	self assert: empty numberOfObjects equals: 0.
 	self assert: empty numberOfConnections equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testBasic02 [
 
 	empty objects: (1 to: 10).
@@ -34,7 +36,7 @@ RSAdjacencyMatrixBuilderTest >> testBasic02 [
 	self assert: empty numberOfConnections equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testBasic03 [
 
 	empty objects: #( 'hello' 'bonjour' 'Guten Morgen' ).
@@ -42,7 +44,7 @@ RSAdjacencyMatrixBuilderTest >> testBasic03 [
 	self assert: empty numberOfConnections equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testConnections01 [
 
 	empty connections: {
@@ -56,13 +58,13 @@ RSAdjacencyMatrixBuilderTest >> testConnections01 [
 	self deny: (empty does: 1 dependsOn: 42)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testCycle01 [
 
 	self deny: b hasCycle
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testCycle02 [
 
 	b := RSAdjacencyMatrixBuilder new.
@@ -80,13 +82,13 @@ RSAdjacencyMatrixBuilderTest >> testCycle02 [
 	self assert: b hasCycle
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testCycle03 [
 
 	self deny: empty hasCycle
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testCycle04 [
 
 	b := RSAdjacencyMatrixBuilder new.
@@ -122,7 +124,7 @@ RSAdjacencyMatrixBuilderTest >> testCycle04 [
 	self assert: (b getAllCycles includes: (Set withAll: #(3 4)))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testIncomingConnectionsOf [
 	self assert: (b incomingConnectionsOf: 3) equals: #(3).
 	self assert: (b numberOfIncomingConnectionsOf: 4) equals: 1.
@@ -131,14 +133,14 @@ RSAdjacencyMatrixBuilderTest >> testIncomingConnectionsOf [
 	self assert: (b numberOfIncomingConnectionsOf: 1) equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testOutgoingConnectionsOf [
 	self assert: (b outgoingConnectionsOf: 1) equals: #(2 3).
 	self assert: (b numberOfOutgoingConnectionsOf: 1) equals: 2.
 	self assert: (b numberOfOutgoingConnectionsOf: 2) equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testRendering01 [
 	| canvas allCells |
 	canvas := b build.
@@ -155,13 +157,13 @@ RSAdjacencyMatrixBuilderTest >> testRendering01 [
 	self assert: allCells second color equals: b connectingColor
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testSorting01 [
 	b build.
 	self assert: b objects equals: (1 to: 4)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAdjacencyMatrixBuilderTest >> testSorting02 [
 	b := RSAdjacencyMatrixBuilder new.
 	b objects: (1 to: 4).

--- a/src/Roassal-Global-Tests/RSAttachPointTest.class.st
+++ b/src/Roassal-Global-Tests/RSAttachPointTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSAttachPointTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Shapes'
+	#name : 'RSAttachPointTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Shapes',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Shapes'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAttachPointTest >> testBorderAttachPoint [
 	| b1 b2 l c |
 	b1 := RSBox new size: 20.
@@ -25,7 +27,7 @@ RSAttachPointTest >> testBorderAttachPoint [
 	self assert: (l attachPoint endingPointOf: l) equals: 50 @ 45
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAttachPointTest >> testCenteredAttachPoint [
 	| b1 b2 l c |
 	b1 := RSBox new size: 20.
@@ -46,7 +48,7 @@ RSAttachPointTest >> testCenteredAttachPoint [
 	self assert: (l attachPoint endingPointOf: l) equals: 60 @ 50
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAttachPointTest >> testHorizontalAttachPoint [
 	| b1 b2 l c |
 	b1 := RSBox new size: 20.
@@ -67,7 +69,7 @@ RSAttachPointTest >> testHorizontalAttachPoint [
 	self assert: (l attachPoint endingPointOf: l) equals: 50 @ 50
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAttachPointTest >> testInverted [
 	| ap e1 e2 line |
 	ap := RSCenteredAttachPoint new.
@@ -87,7 +89,7 @@ RSAttachPointTest >> testInverted [
 	self assert: e1 position equals: line endPoint
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSAttachPointTest >> testVerticalAttachPoint [
 	| b1 b2 l c |
 	b1 := RSBox new size: 20.

--- a/src/Roassal-Global-Tests/RSCameraTest.class.st
+++ b/src/Roassal-Global-Tests/RSCameraTest.class.st
@@ -1,17 +1,19 @@
 Class {
-	#name : #RSCameraTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Core'
+	#name : 'RSCameraTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Core',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCameraTest >> testMatrix [
 	| canvas |
 	canvas := RSCanvas new.
 	self assert: canvas camera matrix isIdentity
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCameraTest >> testPosition [
 
 	| c |
@@ -21,7 +23,7 @@ RSCameraTest >> testPosition [
 	self assert: c camera position equals: 25 @ 15
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCameraTest >> testVisibleArea [
 	| canvas |
 	canvas := RSCanvas new.
@@ -29,7 +31,7 @@ RSCameraTest >> testVisibleArea [
 	self assert: canvas visibleRectangle equals: (-50 asPoint corner: 50 asPoint)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCameraTest >> testVisibleAreaTopLeft [
 	| canvas |
 	canvas := RSCanvas new.
@@ -38,7 +40,7 @@ RSCameraTest >> testVisibleAreaTopLeft [
 	self assert: canvas visibleRectangle equals: (0 asPoint corner: 100 asPoint)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCameraTest >> testVisibleAreaWTopLeftWithScale [
 	| canvas |
 	canvas := RSCanvas new.
@@ -48,7 +50,7 @@ RSCameraTest >> testVisibleAreaWTopLeftWithScale [
 	self assert: canvas visibleRectangle equals: (0 asPoint corner: 50 asPoint)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCameraTest >> testVisibleAreaWithScale [
 	| canvas |
 	canvas := RSCanvas new.

--- a/src/Roassal-Global-Tests/RSChannelTest.class.st
+++ b/src/Roassal-Global-Tests/RSChannelTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSChannelTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Mondrian'
+	#name : 'RSChannelTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Mondrian',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Mondrian'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSChannelTest >> testAnnouncement [
 
 	| c start end channel |
@@ -23,7 +25,7 @@ RSChannelTest >> testAnnouncement [
 	self assert: start announcer numberOfSubscriptions equals: 5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSChannelTest >> testBasic [
 
 	| c m mondrianNodes oddLabel evenLabel bigLabel smallLabel g channel |
@@ -82,7 +84,7 @@ RSChannelTest >> testBasic [
 	oddLabel announce: RSMouseClick
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSChannelTest >> testBasicWithCallbacks [
 
 	| c m mondrianNodes oddLabel evenLabel bigLabel smallLabel g channel value |
@@ -149,7 +151,7 @@ RSChannelTest >> testBasicWithCallbacks [
 	self assert: value asArray equals: #('ONOdd' 'OFFOdd')
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSChannelTest >> testLocationsOfUnderlines [
 
 	| c lbl1 lbl2 box channel1 channel2 markBlue markRed |

--- a/src/Roassal-Global-Tests/RSCircleVennDiagramTest.class.st
+++ b/src/Roassal-Global-Tests/RSCircleVennDiagramTest.class.st
@@ -1,20 +1,22 @@
 Class {
-	#name : #RSCircleVennDiagramTest,
-	#superclass : #RSTest,
+	#name : 'RSCircleVennDiagramTest',
+	#superclass : 'RSTest',
 	#instVars : [
 		'vennDiagram'
 	],
-	#category : 'Roassal-Global-Tests-Builder'
+	#category : 'Roassal-Global-Tests-Builder',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Builder'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSCircleVennDiagramTest >> setUp [
 	super setUp.
 
 	vennDiagram := RSCircleVennDiagram new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCircleVennDiagramTest >> testBasicVennDiagramOpen [
 
 	| window |
@@ -22,21 +24,21 @@ RSCircleVennDiagramTest >> testBasicVennDiagramOpen [
 	window delete
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCircleVennDiagramTest >> testVennDiagramConvertsBigSetInputToSet [
 
 	vennDiagram bigSet: { 1 . 2 }.
 	self assert: vennDiagram bigSet class equals: Set
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCircleVennDiagramTest >> testVennDiagramConvertsSmallSetInputToSet [
 
 	vennDiagram smallSet: { 1 . 2 }.
 	self assert: vennDiagram smallSet class equals: Set
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCircleVennDiagramTest >> testVennDiagramOneSet [
 
 	vennDiagram bigSet:  { 3 . 2 }.
@@ -44,7 +46,7 @@ RSCircleVennDiagramTest >> testVennDiagramOneSet [
 	self assert: vennDiagram canvas shapes size equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCircleVennDiagramTest >> testVennDiagramTwoSets [
 
 	vennDiagram bigSet:  { 3 . 2 }.

--- a/src/Roassal-Global-Tests/RSCollectionTest.class.st
+++ b/src/Roassal-Global-Tests/RSCollectionTest.class.st
@@ -1,15 +1,17 @@
 Class {
-	#name : #RSCollectionTest,
-	#superclass : #ParametrizedTestCase,
+	#name : 'RSCollectionTest',
+	#superclass : 'ParametrizedTestCase',
 	#instVars : [
 		'shapeCollection',
 		'shapeCollectionClass',
 		'canvas'
 	],
-	#category : 'Roassal-Global-Tests-Rendering'
+	#category : 'Roassal-Global-Tests-Rendering',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Rendering'
 }
 
-{ #category : #'building suites' }
+{ #category : 'building suites' }
 RSCollectionTest class >> testParameters [
 	| m classesToConsider |
 	m := ParametrizedTestMatrix new.
@@ -20,7 +22,7 @@ RSCollectionTest class >> testParameters [
 	^ m
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RSCollectionTest >> setUp [
 	super setUp.
 	shapeCollection := self shapeCollectionClass new.
@@ -28,29 +30,29 @@ RSCollectionTest >> setUp [
 	canvas shapeCollection: shapeCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RSCollectionTest >> shapeCollection [
 	^ shapeCollection
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RSCollectionTest >> shapeCollection: anObject [
 
 	shapeCollection := anObject
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RSCollectionTest >> shapeCollectionClass [
 
 	^ shapeCollectionClass
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RSCollectionTest >> shapeCollectionClass: anObject [
 	shapeCollectionClass := anObject
 ]
 
-{ #category : #'tests - adding' }
+{ #category : 'tests - adding' }
 RSCollectionTest >> testAdd [
 	canvas add: RSBox new.
 	self assert: canvas shapes size equals: 1.
@@ -81,7 +83,7 @@ RSCollectionTest >> testAdd [
 	self assert: shapeCollection size equals: 3
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCollectionTest >> testContainsPoint [
 	| box shape position |
 	position := 1000 asPoint.
@@ -100,7 +102,7 @@ RSCollectionTest >> testContainsPoint [
 	self assert: shape equals: box
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCollectionTest >> testContainsPointInComposite [
 	| box shapes position composite |
 	position := 1000 asPoint.
@@ -119,7 +121,7 @@ RSCollectionTest >> testContainsPointInComposite [
 	self assert: shapes size equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCollectionTest >> testContainsShapeWithInteractions [
 	| box shape position |
 	position := 1000 asPoint.
@@ -138,7 +140,7 @@ RSCollectionTest >> testContainsShapeWithInteractions [
 	self assert: shape equals: box
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCollectionTest >> testGetEntriesFromRectangleInParent [
 
 	| listOfShapes box composite |
@@ -155,7 +157,7 @@ RSCollectionTest >> testGetEntriesFromRectangleInParent [
 	self assert: listOfShapes asArray equals: { composite }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCollectionTest >> testGetShapeFromRectangle [
 
 	| listOfShapes |
@@ -167,7 +169,7 @@ RSCollectionTest >> testGetShapeFromRectangle [
 	self assert: (listOfShapes includes: shapeCollection anyOne)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCollectionTest >> testGetShapesFromRectangle [
 
 	| listOfShapes box1 box2 box3 |
@@ -196,7 +198,7 @@ RSCollectionTest >> testGetShapesFromRectangle [
 			box3 }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCollectionTest >> testGetShapesFromRectangleInCompositeWithChildOutside [
 
 	| listOfShapes box composite |
@@ -214,14 +216,14 @@ RSCollectionTest >> testGetShapesFromRectangleInCompositeWithChildOutside [
 	self assert: listOfShapes asArray isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCollectionTest >> testOneElement [
 
 	shapeCollection add: (RSBox new size: 10).
 	self deny: shapeCollection isEmpty
 ]
 
-{ #category : #'tests - removing' }
+{ #category : 'tests - removing' }
 RSCollectionTest >> testRemoveOneElement [
 	| box |
 	box := RSBox new.
@@ -231,7 +233,7 @@ RSCollectionTest >> testRemoveOneElement [
 	self assert: shapeCollection isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSCollectionTest >> testSortResultArray [
 
 	| shapes a b c d tree e |

--- a/src/Roassal-Global-Tests/RSColoredTreePaletteTest.class.st
+++ b/src/Roassal-Global-Tests/RSColoredTreePaletteTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSColoredTreePaletteTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Colors'
+	#name : 'RSColoredTreePaletteTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Colors',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Colors'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSColoredTreePaletteTest >> testBasic [
 
 	| c nodes lb ctp node1 node2 node3 |
@@ -35,7 +37,7 @@ RSColoredTreePaletteTest >> testBasic [
 	self assert: node1 color ~= node2 color
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSColoredTreePaletteTest >> testLeaves [
 
 	| c nodes lb ctp node1 node2 node3 |
@@ -62,7 +64,7 @@ RSColoredTreePaletteTest >> testLeaves [
 	self assert: ctp totalNumberOfLeaves equals: 5
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSColoredTreePaletteTest >> testPalettes [
 
 	RSColorPalette subclasses do: [ :cls |

--- a/src/Roassal-Global-Tests/RSConnectionTest.class.st
+++ b/src/Roassal-Global-Tests/RSConnectionTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSConnectionTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Mondrian'
+	#name : 'RSConnectionTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Mondrian',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Mondrian'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSConnectionTest >> testBasic [
 
 	| c connection |
@@ -34,13 +36,13 @@ RSConnectionTest >> testBasic [
 	connection deleteAllWindows
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSConnectionTest >> testLastwindowIsNil [
 
 	self assert: RSPopupConnection new lastWindow isNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSConnectionTest >> testNumberOfOutputs [
 
 	self assert: RSPopupConnection new numberOfOutputs equals: 0

--- a/src/Roassal-Global-Tests/RSDSMTest.class.st
+++ b/src/Roassal-Global-Tests/RSDSMTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSDSMTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-DSM'
+	#name : 'RSDSMTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-DSM',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'DSM'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testColor [
 	| b |
 
@@ -15,7 +17,7 @@ RSDSMTest >> testColor [
 	b build
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testDefault [
 
 	| dsm |
@@ -23,7 +25,7 @@ RSDSMTest >> testDefault [
 	self assert: dsm numberOfObjects equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testDep [
 
 	| dsm v ts |
@@ -39,7 +41,7 @@ RSDSMTest >> testDep [
 	self assert: ts size equals: 2
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testExample01 [
 	| dsm |
 	dsm := RSDSM new.
@@ -48,7 +50,7 @@ RSDSMTest >> testExample01 [
 	dsm build
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testExample02 [
 
 	| dsm shapes column5 row5 |
@@ -75,7 +77,7 @@ RSDSMTest >> testExample02 [
 	column5 first announce: (RSMouseEnter new shape: column5 first)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testLabelShapeColor [
 	| b shapes |
 	b := RSDSM new.
@@ -91,7 +93,7 @@ RSDSMTest >> testLabelShapeColor [
 	self assert: shapes second color equals: Color red
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testLabelShapeHeight [
 	| b |
 	b := RSDSM new.
@@ -102,7 +104,7 @@ RSDSMTest >> testLabelShapeHeight [
 	self assert: b labelsX first color equals: Color blue
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testLabelsLeftPosition [
 	| b shapes firstColumn |
 	b := RSDSM new.
@@ -117,7 +119,7 @@ RSDSMTest >> testLabelsLeftPosition [
 		self assert: box position y equals: label position y  ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testLabelsTopPosition [
 	| b labels firstRow |
 	b := RSDSM new.
@@ -139,7 +141,7 @@ RSDSMTest >> testLabelsTopPosition [
 		 ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDSMTest >> testUsingXAndY [
 	| b |
 

--- a/src/Roassal-Global-Tests/RSDependencyTest.class.st
+++ b/src/Roassal-Global-Tests/RSDependencyTest.class.st
@@ -1,40 +1,48 @@
 Class {
-	#name : #RSDependencyTest,
-	#superclass : #RSTest,
-	#category : #'Roassal-Global-Tests-Infrastructure'
+	#name : 'RSDependencyTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Infrastructure',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Infrastructure'
 }
 
-{ #category : #'private - asserting' }
+{ #category : 'private - asserting' }
 RSDependencyTest >> assertPackage: p1Name dependOn: p2Name [
 
 	| p1 p2 |
 	p1 := self packageNamed: p1Name.
 	p2 := self packageNamed: p2Name.
-	self assert: (p1 dependentPackages includes: p2)
+	self assert: ((self dependentPackagesOf: p1) includes: p2)
 ]
 
-{ #category : #'private - asserting' }
+{ #category : 'private - asserting' }
 RSDependencyTest >> assertPackage: p1Name doesNotDependOn: p2Name [
 
 	| p1 p2 |
 	p1 := self packageNamed: p1Name.
 	p2 := self packageNamed: p2Name.
-	self deny: (p1 dependentPackages includes: p2)
+	self deny: ((self dependentPackagesOf: p1) includes: p2)
 ]
 
-{ #category : #testing }
+{ #category : 'tests' }
+RSDependencyTest >> dependentPackagesOf: aPackage [ 
+
+	^ (aPackage definedClasses flatCollect: #dependentClasses), aPackage extendedClasses collect: #package as: Set
+]
+
+{ #category : 'testing' }
 RSDependencyTest >> hasPackage: aString [
 
 	^ (self packageNamed: aString) isNotNil
 ]
 
-{ #category : #'private - accessing' }
+{ #category : 'private - accessing' }
 RSDependencyTest >> packageNamed: aSymbol [
 	^ RPackageOrganizer default packageNamed: aSymbol
 		ifAbsent: [ nil ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSDependencyTest >> testDependencies [
 
 	self assertPackage: 'Roassal' doesNotDependOn: 'Roassal-Layouts'.

--- a/src/Roassal-Global-Tests/RSExamplesTest.class.st
+++ b/src/Roassal-Global-Tests/RSExamplesTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSExamplesTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Examples'
+	#name : 'RSExamplesTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Examples',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSExamplesTest class >> validMethods: methods [
 	| result |
 	result := methods select: [ :met |
@@ -15,7 +17,7 @@ RSExamplesTest class >> validMethods: methods [
 	^ result
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSExamplesTest >> executeTest: method in: exampleClass [
 	| res |
 	res := exampleClass perform: method selector.
@@ -24,7 +26,7 @@ RSExamplesTest >> executeTest: method in: exampleClass [
 		description: '''' , method selector, ''', should return a canvas or view.'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSExamplesTest >> testClassSideExamples [
 	| methods errors noSystemWindow |
 	self timeLimit: 10 minutes.
@@ -47,7 +49,7 @@ RSExamplesTest >> testClassSideExamples [
 	self assert: noSystemWindow isEmpty description: 'Some errors in class side examples'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSExamplesTest >> testExamples [
 	"This tests execute all the examples of Roassal. Introspectively, it looks for subclasses of RSAbstractExamples"
 	| clazz withErrors sameResult |

--- a/src/Roassal-Global-Tests/RSForceBasedLayoutTest.class.st
+++ b/src/Roassal-Global-Tests/RSForceBasedLayoutTest.class.st
@@ -1,14 +1,16 @@
 Class {
-	#name : #RSForceBasedLayoutTest,
-	#superclass : #RSTest,
+	#name : 'RSForceBasedLayoutTest',
+	#superclass : 'RSTest',
 	#instVars : [
 		'canvas',
 		'boxes'
 	],
-	#category : 'Roassal-Global-Tests-Layouts'
+	#category : 'Roassal-Global-Tests-Layouts',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Layouts'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSForceBasedLayoutTest >> setUp [
 	super setUp.
 	canvas := RSCanvas new.
@@ -21,7 +23,7 @@ RSForceBasedLayoutTest >> setUp [
 	canvas addAll: boxes
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSForceBasedLayoutTest >> testAddNodesAndEdges [
 
 	| groups |
@@ -34,7 +36,7 @@ RSForceBasedLayoutTest >> testAddNodesAndEdges [
 	self assert: boxes size equals: groups size
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSForceBasedLayoutTest >> testAttributes [
 	RSForceBasedLayout new
 		length: 100;
@@ -84,7 +86,7 @@ RSForceBasedLayoutTest >> testAttributes [
 131 @ 426}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSForceBasedLayoutTest >> testAutoRepulse [
 	self assert: RSForceBasedLayout new autoRepulse equals: false.
 	RSForceBasedLayout new
@@ -133,7 +135,7 @@ RSForceBasedLayoutTest >> testAutoRepulse [
 -20 @ 40}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSForceBasedLayoutTest >> testBasic [
 	RSForceBasedLayout new
 		doNotUseProgressBar;
@@ -181,7 +183,7 @@ RSForceBasedLayoutTest >> testBasic [
 -18 @ 38}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSForceBasedLayoutTest >> testBasic02 [
 	RSForceBasedLayout on: boxes.
 	self assertIntegerPosition: boxes equals: {0 @ -44.

--- a/src/Roassal-Global-Tests/RSHeatmapTest.class.st
+++ b/src/Roassal-Global-Tests/RSHeatmapTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #RSHeatmapTest,
-	#superclass : #RSTest,
+	#name : 'RSHeatmapTest',
+	#superclass : 'RSTest',
 	#instVars : [
 		'builder'
 	],
-	#category : 'Roassal-Global-Tests-DSM'
+	#category : 'Roassal-Global-Tests-DSM',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'DSM'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSHeatmapTest >> setUp [
 	super setUp.
 	builder := RSHeatmap new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHeatmapTest >> testBuildCreateCompositeShapes [
 	| cell |
 	builder objectsX: #('A' 'B' 'C').
@@ -27,22 +29,22 @@ RSHeatmapTest >> testBuildCreateCompositeShapes [
 	self assert: cell children second class equals: RSLabel
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHeatmapTest >> testDataMatrixArrayShouldNotBeEmpty [
 	self should: [builder dataMatrix: {{}. {}. {}}] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHeatmapTest >> testDataMatrixShouldHaveTheSameSize [
 	self should: [builder dataMatrix: {{100. 200}. {100. 200. 300}. {100}}] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHeatmapTest >> testDataMatrixShouldNotBeEmpty [
 	self should: [builder dataMatrix: #()] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHeatmapTest >> testHeatmapContainsAGradientLegend [
 	| legend |
 	builder objectsX: #('A' 'B' 'C').
@@ -56,7 +58,7 @@ RSHeatmapTest >> testHeatmapContainsAGradientLegend [
 	self assert: legend children third isLabel
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSHeatmapTest >> testShouldShowCellLabelsIsTrue [
 	self assert: builder shouldShowCellLabels
 ]

--- a/src/Roassal-Global-Tests/RSMondrianTest.class.st
+++ b/src/Roassal-Global-Tests/RSMondrianTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #RSMondrianTest,
-	#superclass : #RSTest,
+	#name : 'RSMondrianTest',
+	#superclass : 'RSTest',
 	#instVars : [
 		'm'
 	],
-	#category : 'Roassal-Global-Tests-Mondrian'
+	#category : 'Roassal-Global-Tests-Mondrian',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Mondrian'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSMondrianTest >> setUp [
 	super setUp.
 	m := RSMondrian new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testBasic [
 	| someNodes |
 	someNodes := m nodes: (1 to: 5).
@@ -23,7 +25,7 @@ RSMondrianTest >> testBasic [
 	self assert: someNodes asArray equals: m canvas shapes asArray
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testBasic2 [
 	| someNodes |
 	m shape size: #yourself.
@@ -42,7 +44,7 @@ RSMondrianTest >> testBasic2 [
 	self assert: someNodes asArray equals: m canvas shapes asArray
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testColoredNodesForEach [
 
 	m shape color: Color blue.
@@ -56,7 +58,7 @@ RSMondrianTest >> testColoredNodesForEach [
 	self assert: (m canvas nodes flatCollect: [ :e | e children collect: #color ]) asSet asArray equals: { Color red }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testComposingMondrian [
 
 	| c compo m2 nodes |
@@ -88,7 +90,7 @@ RSMondrianTest >> testComposingMondrian [
 	self assertIntegerPosition: nodes equals: {2 @ 2. 12 @ 2. 2 @ 12. 12 @ 12}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testEdges [
 
 	m nodes: (1 to: 100).
@@ -100,7 +102,7 @@ RSMondrianTest >> testEdges [
 	self assert: m canvas numberOfEdges equals: 99
 ]
 
-{ #category : #'tests - labeled shape' }
+{ #category : 'tests - labeled shape' }
 RSMondrianTest >> testLabeled01 [
 
 	| shape |
@@ -118,7 +120,7 @@ RSMondrianTest >> testLabeled01 [
 	self assert: shape nodes second text equals: '42'
 ]
 
-{ #category : #'tests - labeled shape' }
+{ #category : 'tests - labeled shape' }
 RSMondrianTest >> testLabeled02 [
 
 	| shape |
@@ -136,7 +138,7 @@ RSMondrianTest >> testLabeled02 [
 	self assert: shape nodes first class equals: RSBox
 ]
 
-{ #category : #'tests - labeled shape' }
+{ #category : 'tests - labeled shape' }
 RSMondrianTest >> testLabeled03HasModel [
 
 	m shape box labeled.
@@ -146,7 +148,7 @@ RSMondrianTest >> testLabeled03HasModel [
 	self assert: m canvas nodes first model equals: 42
 ]
 
-{ #category : #'tests - labeled shape' }
+{ #category : 'tests - labeled shape' }
 RSMondrianTest >> testLabeled03bisHasModel [
 
 	m shape box labeled.
@@ -156,7 +158,7 @@ RSMondrianTest >> testLabeled03bisHasModel [
 	self assert: m canvas nodes first model equals: 42
 ]
 
-{ #category : #'tests - labeled shape' }
+{ #category : 'tests - labeled shape' }
 RSMondrianTest >> testLabeled04HasModel [
 
 	m shape box labeled.
@@ -167,7 +169,7 @@ RSMondrianTest >> testLabeled04HasModel [
 	self assert: (m canvas nodes allSatisfy: #hasModel)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testLabeledOuterShapes01 [
 
 	| shape |
@@ -179,7 +181,7 @@ RSMondrianTest >> testLabeledOuterShapes01 [
 	self assert: shape class equals: RSBox
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testLabeledOuterShapes02 [
 
 	| shape |
@@ -193,7 +195,7 @@ RSMondrianTest >> testLabeledOuterShapes02 [
 	self assert: shape children first class equals: RSBox
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testLabeledOuterShapes03 [
 
 	| shape |
@@ -209,7 +211,7 @@ RSMondrianTest >> testLabeledOuterShapes03 [
 	self assert: shape children second class equals: RSLabel
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testLabeledOuterShapes04 [
 
 	| shape |
@@ -227,7 +229,7 @@ RSMondrianTest >> testLabeledOuterShapes04 [
 	self assert: shape children second class equals: RSLabel
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testLabeledOuterShapes05 [
 
 	| shape |
@@ -247,7 +249,7 @@ RSMondrianTest >> testLabeledOuterShapes05 [
 	self assert: shape children second class equals: RSLabel
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testNesting [
 
 	| c firstNode subNodes |
@@ -271,7 +273,7 @@ RSMondrianTest >> testNesting [
 	self assertIntegerPosition: subNodes equals: {-10 @ -10. 0 @ -10. 10 @ -10. -10 @ 0. 0 @ 0. 10 @ 0. -10 @ 10. 0 @ 10. 10 @ 10}
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testNodesForEach [
 
 	m nodes: (1 to: 2) forEach: [ :v |
@@ -285,7 +287,7 @@ RSMondrianTest >> testNodesForEach [
 		  m canvas shapes second . m canvas shapes second children first . m canvas shapes second children second }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testNodesForEachAndLAyout [
 
 	m nodes: #(1) forEach: [ :v |
@@ -300,7 +302,7 @@ RSMondrianTest >> testNodesForEachAndLAyout [
 	self assert: m canvas shapes first children first position ~= m canvas shapes first children second position
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testWithNullElement [
 
 	| c lb shape nodes |
@@ -321,7 +323,7 @@ RSMondrianTest >> testWithNullElement [
 	self assert: (lb fromShapes noneSatisfy: [ :s | s model isNil ])
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMondrianTest >> testWithNullElementWithFixed [
 
 	| c shape lb nodes |

--- a/src/Roassal-Global-Tests/RSMonitorEventsTest.class.st
+++ b/src/Roassal-Global-Tests/RSMonitorEventsTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSMonitorEventsTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Shapes'
+	#name : 'RSMonitorEventsTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Shapes',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Shapes'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMonitorEventsTest >> testBasic [
 	| canvas monitor eventClass timeStamp |
 	canvas := RSCanvas new.
@@ -25,14 +27,14 @@ RSMonitorEventsTest >> testBasic [
 	monitor unRegister
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMonitorEventsTest >> testNoTarget [
 	| monitor |
 	monitor := RSEventsMonitor new.
 	self should: [ monitor onNewEventDo: [  ] for: self ] raise: Error
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSMonitorEventsTest >> testWriteToFile [
 	| canvas monitor events box fileName storage |
 	canvas := RSCanvas new.

--- a/src/Roassal-Global-Tests/RSObjectWithPropertyTest.class.st
+++ b/src/Roassal-Global-Tests/RSObjectWithPropertyTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSObjectWithPropertyTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Examples'
+	#name : 'RSObjectWithPropertyTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Examples',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSObjectWithPropertyTest >> testBasic [
 
 	| b1 b2 b3 |
@@ -19,7 +21,7 @@ RSObjectWithPropertyTest >> testBasic [
 	self assert: b3 sparent equals: b1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSObjectWithPropertyTest >> testWithAllChildren [
 
 	| b1 b2 b3 children childrenWithParent schildren b4 |

--- a/src/Roassal-Global-Tests/RSRTreeTest.class.st
+++ b/src/Roassal-Global-Tests/RSRTreeTest.class.st
@@ -1,33 +1,35 @@
 Class {
-	#name : #RSRTreeTest,
-	#superclass : #RSTest,
+	#name : 'RSRTreeTest',
+	#superclass : 'RSTest',
 	#instVars : [
 		'tree'
 	],
-	#category : 'Roassal-Global-Tests-Rendering'
+	#category : 'Roassal-Global-Tests-Rendering',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Rendering'
 }
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RSRTreeTest >> bigTree [
 	^ self newTreeWith: 100
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> emptyTree [
 	^ RTreeCollection new
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RSRTreeTest >> leafs [
 	^ tree root withAllChildren select: [ :node | node isLeaf ]
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RSRTreeTest >> newTree [
 	^ self newTreeWith: 10
 ]
 
-{ #category : #accessing }
+{ #category : 'accessing' }
 RSRTreeTest >> newTreeWith: aNumber [
 	| random |
 	"do not modify this method"
@@ -46,19 +48,19 @@ RSRTreeTest >> newTreeWith: aNumber [
 	^ tree
 ]
 
-{ #category : #running }
+{ #category : 'running' }
 RSRTreeTest >> setUp [
 	super setUp.
 
 	tree := self emptyTree
 ]
 
-{ #category : #'tests - adding' }
+{ #category : 'tests - adding' }
 RSRTreeTest >> testAddNil [
 	self should: [tree add: nil] raise: Error
 ]
 
-{ #category : #'tests - adding' }
+{ #category : 'tests - adding' }
 RSRTreeTest >> testAllChildren [
 	| list |
 	list := tree root withAllChildren.
@@ -74,7 +76,7 @@ RSRTreeTest >> testAllChildren [
 	self assert: list size equals: 3
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testBalanced [
 	1 to: 10 do: [ :each | | box |
 		box := RSBox new.
@@ -86,7 +88,7 @@ RSRTreeTest >> testBalanced [
 	self assert: tree isBalanced
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testContainsPointInRTree [
 	| canvas collection box shape position |
 	canvas := RSCanvas new.
@@ -108,7 +110,7 @@ RSRTreeTest >> testContainsPointInRTree [
 	self assert: shape equals: box
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testHeight [
 	| b1 b2 b3 b4 |
 	b1 := RSBox new size: 10.
@@ -126,7 +128,7 @@ RSRTreeTest >> testHeight [
 	self assert: tree height equals: 3
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testIsBalanced [
 	| boxes |
 	self assert: tree isBalanced.
@@ -137,7 +139,7 @@ RSRTreeTest >> testIsBalanced [
 		tree isBalanced ])
 ]
 
-{ #category : #'tests - adding' }
+{ #category : 'tests - adding' }
 RSRTreeTest >> testOneElement [
 	self assert: tree isEmpty.
 	tree add: (RSBox new size: 10).
@@ -146,7 +148,7 @@ RSRTreeTest >> testOneElement [
 	self assert: tree size equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testOneElementContains [
 	| result |
 	tree add: (RSBox new size: 10).
@@ -157,7 +159,7 @@ RSRTreeTest >> testOneElementContains [
 	self assert: result notEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testOneElementRectangle [
 	| box |
 	box := RSBox new size: 10.
@@ -165,7 +167,7 @@ RSRTreeTest >> testOneElementRectangle [
 	self assert: tree rectangle equals: box encompassingRectangle
 ]
 
-{ #category : #'tests - removing' }
+{ #category : 'tests - removing' }
 RSRTreeTest >> testRemoveLeaf1 [
 	| leafs size shapes shape |
 	tree := self newTree.
@@ -186,7 +188,7 @@ RSRTreeTest >> testRemoveLeaf1 [
 	self assert: size - 2 equals: tree size
 ]
 
-{ #category : #'tests - removing' }
+{ #category : 'tests - removing' }
 RSRTreeTest >> testRemoveLeaf2 [
 	| leafs shapes shape size |
 	tree := self newTree.
@@ -201,7 +203,7 @@ RSRTreeTest >> testRemoveLeaf2 [
 	self assert: tree size + 1  equals: size
 ]
 
-{ #category : #'tests - removing' }
+{ #category : 'tests - removing' }
 RSRTreeTest >> testRemoveLeaf3 [
 	| leafs shapes random toRemove size |
 	tree := self bigTree.
@@ -225,7 +227,7 @@ RSRTreeTest >> testRemoveLeaf3 [
 		self assert: tree isBalanced.]
 ]
 
-{ #category : #'tests - removing' }
+{ #category : 'tests - removing' }
 RSRTreeTest >> testRemoveRootChildren [
 	| box |
 	tree addAll: { box := RSBox new size: 10. }.
@@ -233,7 +235,7 @@ RSRTreeTest >> testRemoveRootChildren [
 	self assert: tree isEmpty
 ]
 
-{ #category : #'tests - removing' }
+{ #category : 'tests - removing' }
 RSRTreeTest >> testRemoveZero [
 	| value |
 	value := false.
@@ -241,7 +243,7 @@ RSRTreeTest >> testRemoveZero [
 	self assert: value
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testSearchPath1 [
 	| path |
 	tree := self emptyTree.
@@ -249,7 +251,7 @@ RSRTreeTest >> testSearchPath1 [
 	self assert: path isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testSearchPath2 [
 	| path shape |
 	tree := self emptyTree.
@@ -258,7 +260,7 @@ RSRTreeTest >> testSearchPath2 [
 	self assert: path asArray equals: { nil -> tree root }
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testSearchPath3 [
 	| nodes path shapes |
 	tree := self newTree.
@@ -275,7 +277,7 @@ RSRTreeTest >> testSearchPath3 [
 	self assert: path asArray first equals: (nil -> tree root)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testSeriousBalance [
 	| random canvas |
 	random := Random new.
@@ -295,7 +297,7 @@ RSRTreeTest >> testSeriousBalance [
 	]
 ]
 
-{ #category : #'tests - adding' }
+{ #category : 'tests - adding' }
 RSRTreeTest >> testThreeElements [
 	| b1 b2 b3 |
 	b1 := RSBox new size: 10.
@@ -309,7 +311,7 @@ RSRTreeTest >> testThreeElements [
 	self assert: tree root right isNotNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testThreeElementsContains [
 	| b1 b2 b3 result |
 	b1 := RSBox new size: 10; entryIndex: 2.
@@ -337,7 +339,7 @@ RSRTreeTest >> testThreeElementsContains [
 	self assert: result asArray equals: { b2. b1. b3 }
 ]
 
-{ #category : #'tests - adding' }
+{ #category : 'tests - adding' }
 RSRTreeTest >> testTwoElements [
 	| b1 b2 |
 	b1 := RSBox new size: 10.
@@ -350,7 +352,7 @@ RSRTreeTest >> testTwoElements [
 	self assert: tree root right isNotNil
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testTwoElementsContains [
 	| b1 b2 result |
 	b1 := RSBox new size: 10; entryIndex: 1.
@@ -369,7 +371,7 @@ RSRTreeTest >> testTwoElementsContains [
 	self assert: result size equals: 2
 ]
 
-{ #category : #'tests - adding' }
+{ #category : 'tests - adding' }
 RSRTreeTest >> testTwoElementsRectangle [
 	| b1 b2 group |
 	b1 := RSBox new size: 10.
@@ -380,14 +382,14 @@ RSRTreeTest >> testTwoElementsRectangle [
 	self assert: tree rectangle equals: group encompassingRectangle
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testZeroElement [
 	self assert: tree isEmpty.
 	self assert: tree root isNilNode.
 	self assert: tree size equals: 0
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testZeroElementContains [
 	| result |
 	result := tree entriesAtPoint: 0@0.
@@ -396,7 +398,7 @@ RSRTreeTest >> testZeroElementContains [
 	self assert: result isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRTreeTest >> testZeroElementRectangle [
 	self assert: tree rectangle equals: (0@0 corner: 0@0)
 ]

--- a/src/Roassal-Global-Tests/RSRoassalTest.class.st
+++ b/src/Roassal-Global-Tests/RSRoassalTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSRoassalTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Core'
+	#name : 'RSRoassalTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Core',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRoassalTest >> testInitializeInRoassal [
 
 	| pkgs methods violating |
@@ -14,7 +16,7 @@ RSRoassalTest >> testInitializeInRoassal [
 	self assert: violating isEmpty description: 'Roassal initialize methods should be categorized in initialization'
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRoassalTest >> testOpen [
 
 	| v |
@@ -23,7 +25,7 @@ RSRoassalTest >> testOpen [
 	v delete
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRoassalTest >> testOpenOnce [
 
 	| v |
@@ -32,7 +34,7 @@ RSRoassalTest >> testOpenOnce [
 	v delete
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRoassalTest >> testRemoveInteractionIfPresent [
 	| box |
 	box := RSBox new.
@@ -51,7 +53,7 @@ RSRoassalTest >> testRemoveInteractionIfPresent [
 	self assert: (box announcer handleEventClass: RSMouseMove)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRoassalTest >> testSubscriberClass [
 	| box |
 	box := RSBox new.
@@ -63,7 +65,7 @@ RSRoassalTest >> testSubscriberClass [
 	{RSPopup activationEvent}, RSPopup removeEvents do: [ :evt | self assert:  (box announcer handleEventClass: evt). ]
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSRoassalTest >> testsRsValue [
 	| myCutomObjectValueProvider posiblesValuesForRoassal model colors |
 	myCutomObjectValueProvider := NSScale category10.

--- a/src/Roassal-Global-Tests/RSShapeBuilderTest.class.st
+++ b/src/Roassal-Global-Tests/RSShapeBuilderTest.class.st
@@ -1,19 +1,21 @@
 Class {
-	#name : #RSShapeBuilderTest,
-	#superclass : #TestCase,
+	#name : 'RSShapeBuilderTest',
+	#superclass : 'TestCase',
 	#instVars : [
 		'b'
 	],
-	#category : 'Roassal-Global-Tests-Mondrian'
+	#category : 'Roassal-Global-Tests-Mondrian',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Mondrian'
 }
 
-{ #category : #running }
+{ #category : 'running' }
 RSShapeBuilderTest >> setUp [
 	super setUp.
 	b := RSShapeBuilder new
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeBuilderTest >> testBox [
 
 	| result |
@@ -25,7 +27,7 @@ RSShapeBuilderTest >> testBox [
 	self assert: (result collect: #model) asArray equals: #(1 2)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeBuilderTest >> testCircle [
 
 	| result |
@@ -37,7 +39,7 @@ RSShapeBuilderTest >> testCircle [
 	self assert: (result collect: #model) asArray equals: #(1 2)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeBuilderTest >> testLabel [
 
 	| result |
@@ -49,7 +51,7 @@ RSShapeBuilderTest >> testLabel [
 	self assert: (result collect: #model) asArray equals: #(1 2)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeBuilderTest >> testLabel2 [
 
 	| result |
@@ -70,7 +72,7 @@ RSShapeBuilderTest >> testLabel2 [
 	self assert: result first width < result second width
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeBuilderTest >> testLabeled [
 
 	| shape |
@@ -89,7 +91,7 @@ RSShapeBuilderTest >> testLabeled [
 	self assert: shape children first class equals: RSBox
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeBuilderTest >> testLabeled02 [
 
 	| shape lbl |
@@ -106,7 +108,7 @@ RSShapeBuilderTest >> testLabeled02 [
 	self assert: shape children first class equals: RSBox
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeBuilderTest >> testLabeled03 [
 
 	| shape lbl |
@@ -123,7 +125,7 @@ RSShapeBuilderTest >> testLabeled03 [
 	self assert: shape children first class equals: RSBox
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeBuilderTest >> testWithBorder [
 
 	| result shape |

--- a/src/Roassal-Global-Tests/RSShapeTest.class.st
+++ b/src/Roassal-Global-Tests/RSShapeTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSShapeTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Shapes'
+	#name : 'RSShapeTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Shapes',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Shapes'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testAllConnectedShapes [
 	| canvas shapes lb node1 node2 node3 node5 node6 |
 	canvas := RSCanvas new.
@@ -35,7 +37,7 @@ RSShapeTest >> testAllConnectedShapes [
 	self assert: node5 allRecursiveConnectedNodes equals: node6 allRecursiveConnectedNodes
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testBorderDoUpdatesInvalidateShape [
 
 	| tmp1 tmp3 |
@@ -54,7 +56,7 @@ RSShapeTest >> testBorderDoUpdatesInvalidateShape [
 		equals: ( -16 asPoint corner: 16 asPoint)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testChangeBorderUpdatesEncompassingRectangle [
 	| box |
 	box := RSBox new
@@ -71,7 +73,7 @@ RSShapeTest >> testChangeBorderUpdatesEncompassingRectangle [
 		equals: (-14 asPoint corner: 14 asPoint)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testChangeBorderWidthUpdatesEncompassingRectangle [
 	| box |
 	box := RSBox new
@@ -89,7 +91,7 @@ RSShapeTest >> testChangeBorderWidthUpdatesEncompassingRectangle [
 		equals: (-16 asPoint corner: 16 asPoint)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testEmptyIndexesArray [
 
 	| box |
@@ -97,7 +99,7 @@ RSShapeTest >> testEmptyIndexesArray [
 	self assert: box indexesFromRoot isEmpty
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testEncompassingRectangleContainsBorderWidth [
 	| box |
 	box := RSBox new
@@ -109,7 +111,7 @@ RSShapeTest >> testEncompassingRectangleContainsBorderWidth [
 	self assert: box encompassingRectangle equals: (-7 asPoint corner: 7 asPoint)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testExtent [
 	| extent box |
 	extent := 100@100.
@@ -118,7 +120,7 @@ RSShapeTest >> testExtent [
 	self assert: box extent equals: extent
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testExtentWithBorder [
 	| extent box |
 	extent := 100@100.
@@ -128,7 +130,7 @@ RSShapeTest >> testExtentWithBorder [
 	self assert: box extent equals: extent
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testExtentWithBorderMin [
 	| extent box borderWidth|
 	extent := 1@1.
@@ -139,7 +141,7 @@ RSShapeTest >> testExtentWithBorderMin [
 	self assert: box extent equals: borderWidth asPoint.
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testHasModel [
 
 	self deny: RSCircle new hasModel.
@@ -148,7 +150,7 @@ RSShapeTest >> testHasModel [
 	self deny: RSLine new hasModel
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testIncomingAndOutgoingShapes [
 
 	| c shapes lb node1 node5 |
@@ -174,7 +176,7 @@ RSShapeTest >> testIncomingAndOutgoingShapes [
 	self assert: node5 outgoingShapes equals: (c shapesFromModels: #(10 11))
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testIndexesArray [
 
 	| box canvas |
@@ -186,7 +188,7 @@ RSShapeTest >> testIndexesArray [
 	self assert: box indexesFromRoot first equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testIndexesArrayWithComposites [
 
 	| box canvas comp box1 comp1 |
@@ -208,7 +210,7 @@ RSShapeTest >> testIndexesArrayWithComposites [
 	self assert: box1 indexesFromRoot second equals: 1
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testInvert [
 
 	| rectangle canvas positionBefore |
@@ -223,7 +225,7 @@ RSShapeTest >> testInvert [
 	self assert: rectangle position equals: (positionBefore y @ positionBefore x)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testModelForIt [
 
 	| s |
@@ -233,7 +235,7 @@ RSShapeTest >> testModelForIt [
 	self assert: s color equals: Color pink
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testModels [
 
 	| shapes |
@@ -244,7 +246,7 @@ RSShapeTest >> testModels [
 	self assert: (shapes collect: #width) asSet asArray equals: #(10)
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testModelsSize [
 
 	| shapes |
@@ -256,7 +258,7 @@ RSShapeTest >> testModelsSize [
 	self assert: (shapes collect: #height) asArray equals: (1 to: 10) asArray
 ]
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSShapeTest >> testTranslateMiddleRightTo [
 
 	| c center lbl |

--- a/src/Roassal-Global-Tests/RSSunburstBuilderTest.class.st
+++ b/src/Roassal-Global-Tests/RSSunburstBuilderTest.class.st
@@ -2,12 +2,14 @@
 A RSSunburstBuilderTest is a test class for testing the behavior of RSSunburstBuilder
 "
 Class {
-	#name : #RSSunburstBuilderTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Examples'
+	#name : 'RSSunburstBuilderTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Examples',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Examples'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSSunburstBuilderTest >> testBasic [
 	| segment1 segment2 line attachPoint startPoint endPoint |
 	segment1 := RSPieSlice new

--- a/src/Roassal-Global-Tests/RSTest.class.st
+++ b/src/Roassal-Global-Tests/RSTest.class.st
@@ -2,17 +2,19 @@
 I am the top class for tests
 "
 Class {
-	#name : #RSTest,
-	#superclass : #TestCase,
-	#category : 'Roassal-Global-Tests-Core'
+	#name : 'RSTest',
+	#superclass : 'TestCase',
+	#category : 'Roassal-Global-Tests-Core',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Core'
 }
 
-{ #category : #testing }
+{ #category : 'testing' }
 RSTest class >> isAbstract [
 	^ self = RSTest
 ]
 
-{ #category : #asserting }
+{ #category : 'asserting' }
 RSTest >> assertIntegerPosition: shapes equals: anArray [
 	self
 		assert: (shapes collect: [ :each | each position asIntegerPoint ] as: Array)

--- a/src/Roassal-Global-Tests/RSWrapLabelTest.class.st
+++ b/src/Roassal-Global-Tests/RSWrapLabelTest.class.st
@@ -1,10 +1,12 @@
 Class {
-	#name : #RSWrapLabelTest,
-	#superclass : #RSTest,
-	#category : 'Roassal-Global-Tests-Wrap'
+	#name : 'RSWrapLabelTest',
+	#superclass : 'RSTest',
+	#category : 'Roassal-Global-Tests-Wrap',
+	#package : 'Roassal-Global-Tests',
+	#tag : 'Wrap'
 }
 
-{ #category : #tests }
+{ #category : 'tests' }
 RSWrapLabelTest >> testWrapStrategyShouldNotProduceDuplicateLabels [
 	| labelBuilder labels line |
 	labelBuilder := RSMultilineLabelBuilder new.

--- a/src/Roassal-Global-Tests/RTNilNode.extension.st
+++ b/src/Roassal-Global-Tests/RTNilNode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RTNilNode }
+Extension { #name : 'RTNilNode' }
 
-{ #category : #'*Roassal-Global-Tests' }
+{ #category : '*Roassal-Global-Tests' }
 RTNilNode class >> example [
 	| null |
 	null := self new.

--- a/src/Roassal-Global-Tests/RTNode.extension.st
+++ b/src/Roassal-Global-Tests/RTNode.extension.st
@@ -1,6 +1,6 @@
-Extension { #name : #RTNode }
+Extension { #name : 'RTNode' }
 
-{ #category : #'*Roassal-Global-Tests' }
+{ #category : '*Roassal-Global-Tests' }
 RTNode class >> example [
 	| root left right |
 	"you can manually manipulate the RNode, but you should use RSRTreeShapeCollection"
@@ -16,7 +16,7 @@ RTNode class >> example [
 	^ StInspectorPresenter openOn: root
 ]
 
-{ #category : #'*Roassal-Global-Tests' }
+{ #category : '*Roassal-Global-Tests' }
 RTNode class >> exampleAdd [
 	| root |
 	"same result but with balance"

--- a/src/Roassal-Global-Tests/package.st
+++ b/src/Roassal-Global-Tests/package.st
@@ -1,1 +1,1 @@
-Package { #name : #'Roassal-Global-Tests' }
+Package { #name : 'Roassal-Global-Tests' }


### PR DESCRIPTION
God knows why, this PR does a lot of format changes too.. For actual changes, look for string `dependentPackagesOf:` in the PR files preview.