### PR TITLE
Optimize `RSDSM` by using the non-generic method to add all shapes in the canvas

### DIFF
--- a/src/Roassal-DSM/RSDSM.class.st
+++ b/src/Roassal-DSM/RSDSM.class.st
@@ -323,7 +323,7 @@ RSDSM >> objectsY: someObjects [
 { #category : 'rendering' }
 RSDSM >> renderIn: aCanvas [
 	shapes := self createShapes.
-	aCanvas addAll: shapes.
+	aCanvas addAllShapes: shapes.
 	self layoutShapes: shapes.
 	self addLabelsIfNecessary: aCanvas
 ]


### PR DESCRIPTION
The time profiler reports me an improvment from 3701ms to 3477ms for 1000 entities in the DSM

before
![image](https://github.com/user-attachments/assets/1071c11d-991b-45c6-b590-dcc3f89d05d5)

after
![image](https://github.com/user-attachments/assets/26433e21-a07f-4883-9502-843b2542d69d)
