### PR TITLE
Move 3 extension methods in Roassal-Pharo12 package to Roassal-Examples

### DIFF
--- a/src/Roassal-Examples/Package.extension.st
+++ b/src/Roassal-Examples/Package.extension.st
@@ -1,0 +1,31 @@
+Extension { #name : 'Package' }
+
+{ #category : '*Roassal-Examples' }
+Package >> dependentPackages [
+	"
+	Return the list of packages that I depend on
+
+	(PackageOrganizer default packageNamed: 'Roassal') dependentPackages
+	"
+	^ (self definedClasses flatCollect: #dependentClasses), self extendedClasses collect: #package as: Set
+]
+
+{ #category : '*Roassal-Examples' }
+Package >> dependentPackagesWithOccurences [
+	"
+	Return the list of packages that I depend on. The result may includes several times the same packages. This reflects the number of dependencies.
+
+	(PackageOrganizer default packageNamed: 'Athens-Cairo') dependentPackagesWithOccurences
+	"
+	^ (self definedClasses flatCollect: #dependentClassesWithOccurences as: Bag) collect: #package
+]
+
+{ #category : '*Roassal-Examples' }
+Package >> numberOfDependenciesToward: anotherPackage [
+	"
+	Return the number of dependencies between mysefl and the package provided as argument
+
+	(PackageOrganizer default packageNamed: 'Athens-Cairo') numberOfDependenciesToward: (PackageOrganizer default packageNamed: 'Text-Core')
+	"
+	^ (self dependentPackagesWithOccurences select: [ :p | p == anotherPackage ]) size
+]


### PR DESCRIPTION
Users of those methods are in Roassal-Examples and Roassal-Examples-SVG, so this may be a good place for them.

Fixes #100