### PR TITLE
Replace GoferOperation by HashedCollection in an example

### DIFF
--- a/src/Roassal-Examples/RSLayoutExamples.class.st
+++ b/src/Roassal-Examples/RSLayoutExamples.class.st
@@ -367,10 +367,11 @@ RSLayoutExamples >> example13VisualizeQuatree [
 { #category : 'lines' }
 RSLayoutExamples >> example15SimpleClassHierarchy [
 	<script: 'self new example15SimpleClassHierarchy open'>
+
 	| c methods |
 	c := RSCanvas new.
 
-	GoferOperation withAllSubclassesDo: [ :cls |
+	HashedCollection withAllSubclassesDo: [ :cls |
 		| composite label |
 		methods := cls methods collect: [ :m | RSBox new color: Color red; size: 5; model: m; yourself ] as: RSGroup.
 		methods @ (RSPopup text: #selector).

--- a/src/Roassal-Legend-Examples/RSLegendExamples.class.st
+++ b/src/Roassal-Legend-Examples/RSLegendExamples.class.st
@@ -277,7 +277,7 @@ RSLegendExamples >> example12OnPopup [
 	<script: 'self new example12OnPopup open'>
 	| canvas shapes interaction popup |
 	canvas := RSCanvas new.
-	shapes := GoferOperation withAllSubclasses collect: [ :cls |
+	shapes := HashedCollection withAllSubclasses collect: [ :cls |
 		| boxes |
 		boxes := RSBox models: cls methods forEach: [:box :met |
 			box size: met linesOfCode*0.5+2; color: Color lightGray


### PR DESCRIPTION
This change fixes one of the errors listed in #98 
The replacement has a hierarchy with a similar number of classes as the original. I had this care to keep the essence of this example.