### PR TITLE
CI: use tinchodias/PharoTestsAction

### DIFF
--- a/.github/workflows/runTestForRelease.yml
+++ b/.github/workflows/runTestForRelease.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
         
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 
@@ -42,7 +42,7 @@ jobs:
       # This will delete roassal and numeric scales and it executes the tests again
       - name: Run pharo Tests
         id: tests
-        uses: akevalion/PharoTestsAction@v1
+        uses: tinchodias/PharoTestsAction@v2
         with:
           removes-repo: 'Roassal, Numeric'
           baseline: 'Roassal'

--- a/.github/workflows/runTestForRelease.yml
+++ b/.github/workflows/runTestForRelease.yml
@@ -42,7 +42,7 @@ jobs:
       # This will delete roassal and numeric scales and it executes the tests again
       - name: Run pharo Tests
         id: tests
-        uses: tinchodias/PharoTestsAction@v2
+        uses: tinchodias/PharoTestsAction@v3
         with:
           removes-repo: 'Roassal, Numeric'
           baseline: 'Roassal'

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -43,7 +43,7 @@ jobs:
       # This will delete roassal and numeric scales and it executes the tests again
       - name: Run pharo Tests
         id: tests
-        uses: tinchodias/PharoTestsAction@v2
+        uses: tinchodias/PharoTestsAction@v3
         with:
           removes-repo: 'Roassal, Numeric'
           baseline: 'Roassal'

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
         
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.12.0
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 
@@ -43,7 +43,7 @@ jobs:
       # This will delete roassal and numeric scales and it executes the tests again
       - name: Run pharo Tests
         id: tests
-        uses: akevalion/PharoTestsAction@v1
+        uses: tinchodias/PharoTestsAction@v2
         with:
           removes-repo: 'Roassal, Numeric'
           baseline: 'Roassal'


### PR DESCRIPTION
Temporarily use a fork of https://github.com/akevalion/PharoTestsAction that fixes bugs in Pharo >= 13 (https://github.com/akevalion/PharoTestsAction/issues/1).