### PR TITLE
Remove Roassal-Bloc's redundant method extension to RSCanvas

### DIFF
--- a/src/Roassal-Bloc/RSCanvas.extension.st
+++ b/src/Roassal-Bloc/RSCanvas.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : 'RSCanvas' }
 
 { #category : '*Roassal-Bloc' }
-RSCanvas >> host [
-
-	^ host
-]
-
-{ #category : '*Roassal-Bloc' }
 RSCanvas >> useBlocHost [
 
 	host := RSBlocHost new


### PR DESCRIPTION
When loading Bloc package via:
```
[Metacello new
    baseline: 'Roassal';
    repository: 'github://pharo-graphics/Roassal';
    load: 'BlocFull' ] on: MCMergeOrLoadWarning do: [:warning | warning load ]
```
this redundant extension produced in Iceberg a dirty package in Roassal repo.