### PR TITLE
Backport bug-fixing from Pharo14 to Pharo13 (again)

### DIFF
--- a/src/BaselineOfRoassal/BaselineOfRoassal.class.st
+++ b/src/BaselineOfRoassal/BaselineOfRoassal.class.st
@@ -99,7 +99,7 @@ BaselineOfRoassal >> baselineOfCommon: spec [
 { #category : 'dependencies' }
 BaselineOfRoassal >> bloc: spec [
 	spec baseline: 'Bloc' with: [
-		spec repository: 'github://pharo-graphics/Bloc:dev-1.0/src' ]
+		spec repository: 'github://pharo-graphics/Bloc:master/src' ]
 ]
 
 { #category : 'API-packages' }

--- a/src/Roassal-Bloc/RSBlocHost.class.st
+++ b/src/Roassal-Bloc/RSBlocHost.class.st
@@ -7,7 +7,8 @@ Class {
 	#instVars : [
 		'space',
 		'canvasElement',
-		'lastMousePosition'
+		'lastMousePosition',
+		'dirtyRectangle'
 	],
 	#category : 'Roassal-Bloc-Core',
 	#package : 'Roassal-Bloc',
@@ -26,6 +27,17 @@ RSBlocHost >> canvasElement [
 RSBlocHost >> defaultWindowTitle [
 
 	^ super defaultWindowTitle , ' - Bloc'
+]
+
+{ #category : 'dirty areas' }
+RSBlocHost >> dirtyRectangle: aRectangleOrNil [
+	"Copied from RSMorphicHost"
+
+	| visibleRectangle |
+	dirtyRectangle := aRectangleOrNil.
+	dirtyRectangle ifNil: [ ^ self ].
+	visibleRectangle := canvas visibleRectangle.
+	dirtyRectangle := dirtyRectangle intersect: visibleRectangle
 ]
 
 { #category : 'accessing' }
@@ -70,4 +82,14 @@ RSBlocHost >> space [
 	"Answer the BlSpace where the the canvas has been opened. If it wasn't opened, the answer is nil."
 
 	^ space
+]
+
+{ #category : 'dirty areas' }
+RSBlocHost >> updateDirtyRectangleWith: aRectangle [
+	"Copied from RSMorphicHost"
+
+	self dirtyRectangle:
+		(dirtyRectangle
+			 ifNil: [ aRectangle ]
+			 ifNotNil: [ dirtyRectangle merge: aRectangle ])
 ]

--- a/src/Roassal-Bloc/RSCanvas.extension.st
+++ b/src/Roassal-Bloc/RSCanvas.extension.st
@@ -1,12 +1,6 @@
 Extension { #name : 'RSCanvas' }
 
 { #category : '*Roassal-Bloc' }
-RSCanvas >> host [
-
-	^ host
-]
-
-{ #category : '*Roassal-Bloc' }
 RSCanvas >> useBlocHost [
 
 	host := RSBlocHost new

--- a/src/Roassal-Colors/RSGradientPalette.class.st
+++ b/src/Roassal-Colors/RSGradientPalette.class.st
@@ -144,9 +144,10 @@ RSGradientPalette class >> redSalvation [
 { #category : 'view' }
 RSGradientPalette class >> roassalCanvas [
 	<example>
+
 	| canvas gradients |
 	canvas := RSCanvas new.
-	gradients := self class methods select: [ :met | met category = #gradients ].
+	gradients := self class methodsInProtocol: #gradients.
 	canvas addAll: (gradients collect: [ :met |
 		| paint |
 		paint := met selector value: self.
@@ -159,7 +160,7 @@ RSGradientPalette class >> roassalCanvas [
 		]).
 	RSGridLayout on: canvas nodes.
 	canvas @ RSCanvasController.
-	canvas open
+	^ canvas open
 ]
 
 { #category : 'gradients' }

--- a/src/Roassal-Global-Tests/RSExamplesTest.class.st
+++ b/src/Roassal-Global-Tests/RSExamplesTest.class.st
@@ -6,17 +6,18 @@ Class {
 	#tag : 'Examples'
 }
 
-{ #category : 'tests' }
-RSExamplesTest class >> validMethods: methods [
-	| result |
-	result := methods select: [ :met |
-		(met selector beginsWith: 'example') and: [
-			(met hasPragmaNamed: 'noTest') not ] ].
+{ #category : 'private' }
+RSExamplesTest >> exampleMethodsFrom: methods [
 
-	^ result
+	^ (methods
+			reject: [ :each | each hasPragmaNamed: 'noTest' ])
+			select: [ :each | 
+				(each selector beginsWith: 'example')
+					or: [ (each hasPragmaNamed: 'example')
+					or: [ (each hasPragmaNamed: 'sampleInstance') ] ] ]
 ]
 
-{ #category : 'tests' }
+{ #category : 'private' }
 RSExamplesTest >> executeTest: method in: exampleClass [
 	| res |
 	res := exampleClass perform: method selector.
@@ -27,9 +28,10 @@ RSExamplesTest >> executeTest: method in: exampleClass [
 
 { #category : 'tests' }
 RSExamplesTest >> testClassSideExamples [
+
 	| methods errors noSystemWindow |
 	self timeLimit: 10 minutes.
-	methods := self class validMethods: (RSObject withAllSubclasses
+	methods := self exampleMethodsFrom: (RSObject withAllSubclasses
 		flatCollect: [:cls | cls class methods ]).
 	errors := OrderedCollection new.
 	noSystemWindow := OrderedCollection new.
@@ -51,15 +53,17 @@ RSExamplesTest >> testClassSideExamples [
 { #category : 'tests' }
 RSExamplesTest >> testExamples [
 	"This tests execute all the examples of Roassal. Introspectively, it looks for subclasses of RSAbstractExamples"
+
 	| clazz withErrors sameResult |
 	self timeLimit: 10 minutes.
 	clazz := Smalltalk at: #RSAbstractExamples ifAbsent: [ ^ self ].
 	withErrors := OrderedCollection new.
 	sameResult := OrderedCollection new.
+
 	clazz subclasses do: [ :cls |
 		| inst methods |
 		inst := cls new.
-		methods := self class validMethods: cls methods.
+		methods := self exampleMethodsFrom: cls methods.
 
 		methods
 			do: [ :met | | res |


### PR DESCRIPTION
- Fix issue #115 
- Fix issue #117
- Multiple fixes in `Roassal-Bloc` package
   * Load `master`branch instead of old `dev-1.0`
   * Implement invalidation rectangle API that RSCanvas requires from host