### PR TITLE
Simplify scaling in RSAthensMorph and RSAthensRenderer

### DIFF
--- a/src/Roassal/RSAthensMorph.class.st
+++ b/src/Roassal/RSAthensMorph.class.st
@@ -133,8 +133,7 @@ RSAthensMorph >> drawShapes [
 	surface drawDuring: [ :athensCanvas |
 		renderer
 			surface: surface;
-			canvas: athensCanvas;
-			scale: 1.
+			canvas: athensCanvas.
 		roassalCanvas accept: renderer.
 	]
 ]

--- a/src/Roassal/RSAthensMorph.class.st
+++ b/src/Roassal/RSAthensMorph.class.st
@@ -92,7 +92,7 @@ RSAthensMorph >> drawOn: aCanvas [
 					formSet: ((Smalltalk at: #FormSet) extent: self extent asIntegerPoint
 						depth: 32 forms: { surface asForm })
 					at: self bounds origin asIntegerPoint
-					sourceRect: (0 @ 0 extent: surface extent)
+					sourceRect: (0 @ 0 extent: self extent asIntegerPoint)
 					rule: Form blendAlphaScaled ]
 			ifFalse: [
 				aCanvas

--- a/src/Roassal/RSAthensMorph.class.st
+++ b/src/Roassal/RSAthensMorph.class.st
@@ -64,6 +64,8 @@ RSAthensMorph >> checkSession [
 { #category : 'surface management' }
 RSAthensMorph >> createSurface [
 	surface := AthensCairoSurface extent: self extent asIntegerPoint * surfaceScale.
+	surfaceScale > 0 ifTrue: [
+		surface deviceScaleX: surfaceScale y: surfaceScale ].
 	session := Smalltalk session.
 	roassalCanvas ifNotNil: [ roassalCanvas invalidate ]
 ]
@@ -132,7 +134,7 @@ RSAthensMorph >> drawShapes [
 		renderer
 			surface: surface;
 			canvas: athensCanvas;
-			scale: surfaceScale.
+			scale: 1.
 		roassalCanvas accept: renderer.
 	]
 ]

--- a/src/Roassal/RSAthensRenderer.class.st
+++ b/src/Roassal/RSAthensRenderer.class.st
@@ -23,7 +23,6 @@ Class {
 		'showRectangles',
 		'originMatrix',
 		'surface',
-		'scale',
 		'dirtyRectangle'
 	],
 	#category : 'Roassal-Rendering',
@@ -586,27 +585,7 @@ RSAthensRenderer >> paintFor: shape form: form [
 { #category : 'visiting - helpers' }
 RSAthensRenderer >> pathTransformLoadMatrix [
 
-	athensCanvas pathTransform loadAffineTransform:
-		(AthensAffineTransform new
-			x: matrix x * scale;
-			y: matrix y * scale;
-			sx: matrix sx * scale;
-			sy: matrix sy * scale;
-			shx: matrix shx * scale;
-			shy: matrix shy * scale;
-			yourself)
-]
-
-{ #category : 'accessing' }
-RSAthensRenderer >> scale [
-
-	^ scale
-]
-
-{ #category : 'accessing' }
-RSAthensRenderer >> scale: anObject [
-
-	scale := anObject
+	athensCanvas pathTransform loadAffineTransform: matrix
 ]
 
 { #category : 'visiting - helpers' }
@@ -695,7 +674,7 @@ RSAthensRenderer >> visitCanvas: aRSCanvas [
 	athensCanvas setAA: aRSCanvas host antialiasing.
 	aRSCanvas camera accept: self.
 	transformeDirtyRectangle := self transform: dirtyRectangle.
-	athensCanvas pathTransform loadIdentity scaleBy: scale.
+	athensCanvas pathTransform loadIdentity.
 	aRSCanvas shouldClearBackground ifTrue: [
 		self clearRectangle: transformeDirtyRectangle ].
 	modifiedDirtyRectangle := self inverseTransform: transformeDirtyRectangle.
@@ -704,14 +683,14 @@ RSAthensRenderer >> visitCanvas: aRSCanvas [
 	dirtyRectangle := transformeDirtyRectangle.
 	matrix loadIdentity.
 	originMatrix loadIdentity.
-	athensCanvas pathTransform loadIdentity scaleBy: scale.
+	athensCanvas pathTransform loadIdentity.
 	athensCanvas clipBy: transformeDirtyRectangle during: [
 		(aRSCanvas fixedShapes entriesAtRectangle: dirtyRectangle) do: [ :each | each accept: self ] ].
 	aRSCanvas resetDirtyRectangle.
 
 	aRSCanvas shouldShowDirtyRectangle ifFalse: [ ^ self ].
 
-	athensCanvas pathTransform loadIdentity scaleBy: scale.
+	athensCanvas pathTransform loadIdentity.
 	matrix loadIdentity.
 	originMatrix loadIdentity.
 	aRSCanvas camera accept: self.


### PR DESCRIPTION
This pull request removes the scaling support that was added to RSAthensRenderer in pull request #56, and makes RSAthensMorph apply the canvas scale factor through the AthensCairoSurface’s device scale instead.