### PR TITLE
Added new functionalities to the event processor

### DIFF
--- a/src/Roassal-Event/RSAbstractMouseEvent.class.st
+++ b/src/Roassal-Event/RSAbstractMouseEvent.class.st
@@ -7,8 +7,3 @@ Class {
 	#category : 'Roassal-Event',
 	#package : 'Roassal-Event'
 }
-
-{ #category : 'testing' }
-RSAbstractMouseEvent >> isPositionAboveShape [
-	^ shape encompassingRectangle containsPoint: self positionFromCamera
-]

--- a/src/Roassal-Event/RSEvent.class.st
+++ b/src/Roassal-Event/RSEvent.class.st
@@ -18,8 +18,10 @@ Class {
 	#instVars : [
 		'canvas',
 		'morph',
-		'shape',
-		'timeStamp'
+		'currentShape',
+		'timeStamp',
+		'targetShape',
+		'stopPropagation'
 	],
 	#category : 'Roassal-Event',
 	#package : 'Roassal-Event'
@@ -34,7 +36,7 @@ RSEvent >> camera [
 RSEvent >> canvas [
 
 	^ canvas ifNil: [
-		  canvas := shape ifNil: [ nil ] ifNotNil: [ shape canvas ] ]
+		  canvas := targetShape ifNil: [ nil ] ifNotNil: [ targetShape canvas ] ]
 ]
 
 { #category : 'accessing' }
@@ -42,9 +44,20 @@ RSEvent >> canvas: aRSCanvas [
 	canvas := aRSCanvas
 ]
 
+{ #category : 'accessing' }
+RSEvent >> currentShape [
+	^ currentShape
+]
+
+{ #category : 'accessing' }
+RSEvent >> currentShape: aRSShape [
+	currentShape := aRSShape
+]
+
 { #category : 'initialization' }
 RSEvent >> initialize [
 	super initialize.
+	stopPropagation := false.
 	self timeStamp
 ]
 
@@ -60,20 +73,42 @@ RSEvent >> morph: aMorph [
 
 { #category : 'accessing' }
 RSEvent >> shape [
-	^ shape
+	^ self currentShape
 ]
 
 { #category : 'accessing' }
 RSEvent >> shape: aRSShape [
 	"An event should now the shape to which it is related to.
 	The shape has to be set before emitting the event."
-	shape := aRSShape
+	self currentShape: aRSShape
 ]
 
 { #category : 'update' }
 RSEvent >> signalUpdate [
 	"Trigger a refresh of the morph. The method signalUpdate has to be called when some visual properties are changed (e.g., color, position)"
 	morph ifNotNil: [ morph changed ]
+]
+
+{ #category : 'accessing' }
+RSEvent >> stopPropagation [
+	^ stopPropagation
+]
+
+{ #category : 'accessing' }
+RSEvent >> stopPropagation: aBoolean [
+	stopPropagation := aBoolean
+]
+
+{ #category : 'accessing' }
+RSEvent >> targetShape [
+	^ targetShape
+]
+
+{ #category : 'accessing' }
+RSEvent >> targetShape: aRSShape [
+	"An event should now the shape to which it is related to.
+	The shape has to be set before emitting the event."
+	targetShape := aRSShape
 ]
 
 { #category : 'accessing' }

--- a/src/Roassal-Event/RSHighlightableEvent.class.st
+++ b/src/Roassal-Event/RSHighlightableEvent.class.st
@@ -28,6 +28,7 @@ RSHighlightableEvent >> source [
 ]
 
 { #category : 'accessing' }
-RSHighlightableEvent >> source: anElementOrView [
-	source := anElementOrView
+RSHighlightableEvent >> source: aShapeOrCanvas [
+	source := aShapeOrCanvas.
+	self canvas: aShapeOrCanvas canvas
 ]

--- a/src/Roassal-Event/RSKeyboardEvent.class.st
+++ b/src/Roassal-Event/RSKeyboardEvent.class.st
@@ -12,6 +12,14 @@ Class {
 	#package : 'Roassal-Event'
 }
 
+{ #category : 'accessing' }
+RSKeyboardEvent >> fromEvent: aMorphicEvent [
+	self
+		positionFromCamera;
+		keyValue: aMorphicEvent keyValue;
+		keyName: aMorphicEvent key name
+]
+
 { #category : 'initialization' }
 RSKeyboardEvent >> initialize [
 	super initialize.

--- a/src/Roassal-Event/RSMouseMove.class.st
+++ b/src/Roassal-Event/RSMouseMove.class.st
@@ -7,3 +7,8 @@ Class {
 	#category : 'Roassal-Event',
 	#package : 'Roassal-Event'
 }
+
+{ #category : 'accessing' }
+RSMouseMove >> fromEvent: aMorphicEvent [
+	self positionFromCamera
+]

--- a/src/Roassal-Event/RSShapeEvent.class.st
+++ b/src/Roassal-Event/RSShapeEvent.class.st
@@ -12,6 +12,11 @@ Class {
 }
 
 { #category : 'accessing' }
+RSShapeEvent >> fromEvent: aMorphicEvent [
+	"this method is to transform the current position into a new position"
+]
+
+{ #category : 'accessing' }
 RSShapeEvent >> position [
 	^ position ifNil: [ self shape position ]
 ]
@@ -21,10 +26,8 @@ RSShapeEvent >> position: aPoint [
 	position := aPoint
 ]
 
-{ #category : 'accessing' }
+{ #category : 'private' }
 RSShapeEvent >> positionFromCamera [
 	"Return the position from the camera. I.e., 0 @ 0 is at the center of the window if the camera has not been translated"
-	^ canvas
-		ifNotNil: [ canvas camera fromPixelToSpace: self position ]
-		ifNil: [ -250 @ -250 ]
+	self position: (canvas camera fromPixelToSpace: self position)
 ]

--- a/src/Roassal-Examples/RSEvent.extension.st
+++ b/src/Roassal-Examples/RSEvent.extension.st
@@ -1,0 +1,82 @@
+Extension { #name : 'RSEvent' }
+
+{ #category : '*Roassal-Examples' }
+RSEvent class >> example [
+
+	| nodes links canvas captureC bubbleC capture bubble label rect |
+	nodes := #(RSCanvas box1 box2 box3 box4 composite1 composite2 Triangle1).
+	links := { 
+		#RSCanvas -> #box1.
+		#RSCanvas -> #composite1.
+		#RSCanvas -> #composite2.
+		#composite1 -> #box2.
+		#composite1 -> #box3.
+		#composite2 -> #box4.
+		#composite2 -> #Triangle1.
+		}.
+	canvas := RSCanvas new.
+
+	canvas addAll: (RSComposite boxesForModels: nodes).
+	canvas nodes do: [ :n | n children first cornerRadius: 5 ].
+	canvas nodes @ RSDraggable new.
+	RSLineBuilder orthoVertical
+		cornerRadii: 5;
+		withVerticalAttachPoint;
+		shapes: canvas nodes;
+		useAssociations: links.
+	RSTreeLayout new
+		verticalGap: 30;
+		horizontalGap: 30;
+	on: canvas nodes.
+	captureC := RSBlockCPController new
+		block: [ :line | | a b |
+			a := line from encompassingRectangle bottomLeft.
+			b := line to encompassingRectangle leftCenter +(-3 @ 0).
+			{  a. a x@ b y. b  } ].
+	bubbleC := RSBlockCPController new
+		block: [ :line | | a b |
+			a := line from encompassingRectangle topRight.
+			b := line to encompassingRectangle rightCenter +(3@0).
+			{  a. a x@ b y. b  } ].
+	capture := bubble := [ :a :b :c |
+		RSBezier new
+			from: (canvas shapeFromModel: a)
+			to: (canvas shapeFromModel: b);
+			markerStart: (RSEllipse new size: 3);
+			markerEnd: (RSShapeFactory arrow size: 4);
+			controlPointsController: c;
+			yourself.
+		 ].
+	#(RSCanvas composite2 Triangle1) overlappingPairsDo: [ :a :b |
+		| line |
+		line := capture value: a value: b value: captureC.
+		
+		line color: Color red.
+		canvas add: line.
+		label := RSLabel text: '1 Capture'.
+		label fontSize: 5.
+		label color: Color red.
+		label position: line controlPoints second - (label extent / 3).
+		rect := RSBox new fromRectangle: label encompassingRectangle.
+		rect color: (Color white alpha: 0.8).
+		canvas add: rect.
+		canvas add: label.
+		
+		line := bubble value: b value: a value: bubbleC.
+		canvas add: line.
+		line color: Color purple.
+		label := RSLabel text: '3 Bubble'.
+		label fontSize: 5.
+		label color: Color purple.
+		label position: line controlPoints second + (label extent / 2).
+		canvas add: label.
+	].
+	label := RSLabel text: '2 Target'.
+	label fontSize: 5.
+	canvas add: label.
+	label color: Color blue.
+	RSLocation new below
+		move: label on: (canvas shapeFromModel: #Triangle1).
+	canvas @ RSCanvasController.
+	^ canvas open
+]

--- a/src/Roassal-Global-Tests/RSCollectionTest.class.st
+++ b/src/Roassal-Global-Tests/RSCollectionTest.class.st
@@ -118,7 +118,8 @@ RSCollectionTest >> testContainsPointInComposite [
 	self assert: shapes size equals: 1.
 	self assert: shapes first equals: composite.
 	shapes := shapeCollection entriesAtPoint: position.
-	self assert: shapes size equals: 2
+	self assert: shapes size equals: 2.
+	self assert: shapes asArray equals: {box. composite}
 ]
 
 { #category : 'tests' }

--- a/src/Roassal-Interaction/RSAbstractPopupInteraction.class.st
+++ b/src/Roassal-Interaction/RSAbstractPopupInteraction.class.st
@@ -153,11 +153,7 @@ RSAbstractPopupInteraction >> popupKey [
 { #category : 'hooks' }
 RSAbstractPopupInteraction >> registerRemoveEventsOn: aShape [
 	self class removeEvents do: [ :clsEvent |
-		aShape
-			when: clsEvent
-			do: [ :evt |
-				self removePopupOn: evt ]
-			for: self ]
+		aShape when: clsEvent send: #removePopupOn: to: self ]
 ]
 
 { #category : 'hooks' }

--- a/src/Roassal-Shapes/RSAbstractControlPointsLine.class.st
+++ b/src/Roassal-Shapes/RSAbstractControlPointsLine.class.st
@@ -83,8 +83,8 @@ RSAbstractControlPointsLine >> controlPointsController [
 ]
 
 { #category : 'accessing' }
-RSAbstractControlPointsLine >> controlPointsController: aCPController [
-	controlPointsController := aCPController
+RSAbstractControlPointsLine >> controlPointsController: anRSAbstractCPController [
+	controlPointsController := anRSAbstractCPController
 ]
 
 { #category : 'accessing' }

--- a/src/Roassal-Shapes/RSAbstractLine.class.st
+++ b/src/Roassal-Shapes/RSAbstractLine.class.st
@@ -280,6 +280,11 @@ RSAbstractLine >> from: aShapeOrAPoint [
 ]
 
 { #category : 'accessing' }
+RSAbstractLine >> from: anRSBoundingShape to: anotherRSBoundingShape [
+	self from: anRSBoundingShape; to: anotherRSBoundingShape
+]
+
+{ #category : 'accessing' }
 RSAbstractLine >> includedRadius [
 	^ self border width / 2
 ]

--- a/src/Roassal-Shapes/RSComposite.class.st
+++ b/src/Roassal-Shapes/RSComposite.class.st
@@ -236,12 +236,14 @@ c open
 { #category : 'adding' }
 RSComposite >> addEntriesIn: aCollection position: position [
 	| pos result includesPoint |
+	
 	includesPoint := self includesPoint: position.
 	includesPoint ifFalse: [ ^ self ].
 	pos := self matrix rsInverseTransform: position.
 	result := self shapeCollection entriesAtPoint: pos.
 	aCollection addAll: result.
-	includesPoint ifTrue: [ aCollection add: self ]
+	aCollection add: self.
+	
 ]
 
 { #category : 'adding' }

--- a/src/Roassal-Shapes/RSLineBuilder.class.st
+++ b/src/Roassal-Shapes/RSLineBuilder.class.st
@@ -226,6 +226,11 @@ RSLineBuilder >> attachPoint: anAttachPoint [
 	self shape attachPoint: anAttachPoint
 ]
 
+{ #category : 'public - attach point' }
+RSLineBuilder >> attachPointDo: aBlock [
+	aBlock value: self attachPoint
+]
+
 { #category : 'public - configuration' }
 RSLineBuilder >> beDirectional [
 	"When lines are created, this allow for having lines going from A to B, and from B to A"

--- a/src/Roassal-Shapes/RSTLine.trait.st
+++ b/src/Roassal-Shapes/RSTLine.trait.st
@@ -57,8 +57,8 @@ RSTLine >> controlPointsController [
 ]
 
 { #category : 'public - shape' }
-RSTLine >> controlPointsController: aCPController [
-	self shape controlPointsController: aCPController
+RSTLine >> controlPointsController: anRSAbstractCPController [
+	self shape controlPointsController: anRSAbstractCPController
 ]
 
 { #category : 'public - shape' }

--- a/src/Roassal/RSCanvas.class.st
+++ b/src/Roassal/RSCanvas.class.st
@@ -660,6 +660,16 @@ RSCanvas >> shapesWithActionForPosition: aPositionInSpace [
 	^ result
 ]
 
+{ #category : 'event processing' }
+RSCanvas >> shapesWithActionForPositionInPixels: position [
+	| result |
+	"TOP shapes are first"
+	result := OrderedCollection new.
+	result addAll: (fixedShapes entriesAtPoint: position).
+	result addAll: (self shapeCollection entriesAtPoint: (self camera fromPixelToSpace: position)).
+	^ result
+]
+
 { #category : 'accessing' }
 RSCanvas >> shouldClearBackground [
 	"Return whether the screen must be cleaned at each screen refresh"

--- a/src/Roassal/RSEventProcessor.class.st
+++ b/src/Roassal/RSEventProcessor.class.st
@@ -6,10 +6,10 @@ Class {
 	#superclass : 'RSObject',
 	#instVars : [
 		'eventBeginingDragging',
-		'shapeBeingPointed',
 		'roassalCanvas',
 		'athensMorph',
-		'lastMousePosition'
+		'lastMousePosition',
+		'shapesBeingPointed'
 	],
 	#category : 'Roassal-Core',
 	#package : 'Roassal',
@@ -18,24 +18,12 @@ Class {
 
 { #category : 'events - processed' }
 RSEventProcessor >> eventKeyDown: aMorphicEvent [
-	| rsEvent |
-	rsEvent := self eventOfClass: RSKeyDown from: aMorphicEvent.
-	rsEvent
-		position: (roassalCanvas camera fromPixelToSpace: rsEvent position);
-		keyValue: aMorphicEvent keyValue;
-		keyName: aMorphicEvent key name. "(self class keyNameFor: aMorphicEvent keyValue)".
-	rsEvent shape announce: rsEvent
+	self process: aMorphicEvent rsEventClass: RSKeyDown
 ]
 
 { #category : 'events - processed' }
 RSEventProcessor >> eventKeyUp: aMorphicEvent [
-	| rsEvent |
-	rsEvent := self eventOfClass: RSKeyUp from: aMorphicEvent.
-	rsEvent
-		position: (roassalCanvas camera fromPixelToSpace: rsEvent position);
-		keyValue: aMorphicEvent keyValue;
-		keyName: aMorphicEvent key name.
-	rsEvent shape announce: rsEvent
+	self process: aMorphicEvent rsEventClass: RSKeyUp
 ]
 
 { #category : 'events - processed' }
@@ -66,8 +54,8 @@ RSEventProcessor >> eventMouseDoubleClick: aMorphicEvent [
 RSEventProcessor >> eventMouseDragEnd: aMorphicEvent [
 	| rsEvent |
 	rsEvent := self eventOfClass: RSMouseDragEnd from: aMorphicEvent.
-	rsEvent shape: shapeBeingPointed.
-	shapeBeingPointed announce: rsEvent.
+	rsEvent shape: shapesBeingPointed.
+	shapesBeingPointed announce: rsEvent.
 
 	eventBeginingDragging := nil
 ]
@@ -86,8 +74,8 @@ RSEventProcessor >> eventMouseDragStart: aMorphicEvent [
 		ifTrue: [ rsEventClass := RSMouseMiddleDragStart ].
 	rsEvent := self eventOfClass: rsEventClass actionClass: RSMouseDragging from: aMorphicEvent.
 
-	shapeBeingPointed := rsEvent shape.
-	shapeBeingPointed announce: rsEvent
+	shapesBeingPointed := rsEvent shape.
+	shapesBeingPointed announce: rsEvent
 ]
 
 { #category : 'events - processed' }
@@ -99,15 +87,15 @@ RSEventProcessor >> eventMouseDragging: aMorphicEvent [
 	rsEvent position: (roassalCanvas camera fromPixelToSpace: rsEvent position).
 	rsEvent step: step.
 
-	shapeBeingPointed ifNil: [ shapeBeingPointed := rsEvent shape ].
+	shapesBeingPointed ifNil: [ shapesBeingPointed := rsEvent shape ].
 	"If the element was removed during the drag then cancel the event"
-	shapeBeingPointed parent ifNil: [
+	shapesBeingPointed parent ifNil: [
 		eventBeginingDragging := nil.
-		shapeBeingPointed := nil.
+		shapesBeingPointed := nil.
 		^ self ].
 
-	rsEvent shape: shapeBeingPointed.
-	shapeBeingPointed announce: rsEvent.
+	rsEvent shape: shapesBeingPointed.
+	shapesBeingPointed announce: rsEvent.
 	eventBeginingDragging := aMorphicEvent copy
 ]
 
@@ -122,36 +110,28 @@ RSEventProcessor >> eventMouseEnter: aMorphicEvent [
 RSEventProcessor >> eventMouseLeave: aMorphicEvent [
 	| rsEvent |
 	rsEvent := self eventOfClass: RSMouseLeave from: aMorphicEvent.
-	shapeBeingPointed ifNotNil: [
-		rsEvent shape: shapeBeingPointed].
+	shapesBeingPointed ifNotNil: [
+		rsEvent shape: shapesBeingPointed].
 	rsEvent shape announce: rsEvent
 ]
 
 { #category : 'events - processed' }
 RSEventProcessor >> eventMouseMove: aMorphicEvent [
-	| rsEvent |
-	rsEvent := self eventOfClass: RSMouseMove from: aMorphicEvent.
-	rsEvent position: (roassalCanvas camera fromPixelToSpace: rsEvent position).
-	rsEvent shape announce: rsEvent
+	self process: aMorphicEvent rsEventClass: RSMouseMove.
 ]
 
 { #category : 'events - processed' }
 RSEventProcessor >> eventMouseOver: aMorphicEvent [
-	| currentShape rsEvent |
-	shapeBeingPointed ifNil: [
-		shapeBeingPointed := self shapeForEvent: aMorphicEvent ].
-	currentShape := self shapeForEvent: aMorphicEvent.
-	currentShape == shapeBeingPointed
+	| currentShapes difference |
+	currentShapes := self shapesForEvent: aMorphicEvent.
+	shapesBeingPointed ifNil: [ shapesBeingPointed := currentShapes ].
+	(currentShapes hasSameObjects: shapesBeingPointed)
 		ifTrue: [ ^ self ].
-	
-	rsEvent := self newEventOfClass: RSMouseLeave from: aMorphicEvent.
-	rsEvent shape: shapeBeingPointed.
-	shapeBeingPointed announce: rsEvent.
-	
-	shapeBeingPointed := currentShape.
-	rsEvent := self newEventOfClass: RSMouseEnter from: aMorphicEvent.
-	rsEvent shape: shapeBeingPointed.
-	shapeBeingPointed announce: rsEvent
+	difference := shapesBeingPointed difference: currentShapes.
+	self process: difference classEvent: RSMouseLeave event: aMorphicEvent.
+	difference := currentShapes difference: shapesBeingPointed.
+	self process: difference classEvent: RSMouseEnter event: aMorphicEvent.
+	shapesBeingPointed := currentShapes
 ]
 
 { #category : 'events - processed' }
@@ -203,12 +183,12 @@ RSEventProcessor >> isDragging [
 	^ eventBeginingDragging isNotNil
 ]
 
-{ #category : 'lastMousePosition' }
+{ #category : 'accessing' }
 RSEventProcessor >> lastMousePosition [
 	^ lastMousePosition
 ]
 
-{ #category : 'lastMousePosition' }
+{ #category : 'accessing' }
 RSEventProcessor >> lastMousePosition: aPoint [
 	lastMousePosition := aPoint
 ]
@@ -247,6 +227,43 @@ RSEventProcessor >> newEventOfClass: anEventClass from: aMorphicEvent [
 	^ rsEvent
 ]
 
+{ #category : 'events - processing' }
+RSEventProcessor >> process: aListOfShapes classEvent: aRSEventClass event: aMorphicEvent [
+	| listToPropagate rsEvent |
+	aListOfShapes ifEmpty: [ ^ self ].
+	listToPropagate := aListOfShapes.
+	"TODO an idea to reverse or not the list of children"
+	rsEvent := self newEventOfClass: aRSEventClass from: aMorphicEvent.
+	rsEvent targetShape: aListOfShapes first.
+	"aRSEventClass traceCr.
+	listToPropagate traceCr.
+	'' traceCr."
+	self propagate: listToPropagate event: rsEvent. 
+	
+]
+
+{ #category : 'events - processed' }
+RSEventProcessor >> process: aMorphicEvent rsEventClass: aRSEventClass [
+	| rsEvent list |
+	shapesBeingPointed ifNil: [ ^ self ].
+	list := shapesBeingPointed copy.
+	list add: roassalCanvas.
+	rsEvent := self newEventOfClass: aRSEventClass from: aMorphicEvent.
+	rsEvent setPosition: aMorphicEvent.
+	rsEvent targetShape: list first.
+	self propagate: list event: rsEvent.
+]
+
+{ #category : 'events - processing' }
+RSEventProcessor >> propagate: listToPropagate event: rsEvent [
+	listToPropagate do: [ :each |
+		rsEvent currentShape: each.
+		each announce: rsEvent.
+		rsEvent stopPropagation ifTrue: [ ^ self ]
+	].
+	
+]
+
 { #category : 'accessing - shapes' }
 RSEventProcessor >> relativePositionFor: evt [
 	^ evt position - athensMorph bounds origin
@@ -266,6 +283,12 @@ RSEventProcessor >> roassalCanvas: aRSCanvas [
 RSEventProcessor >> shapeForEvent: anEvent [
 	"Return the roassal shape for the event provided as argument"
 	^ roassalCanvas shapeWithActionForPositionInPixels: (self relativePositionFor: anEvent)
+]
+
+{ #category : 'accessing - shapes' }
+RSEventProcessor >> shapesForEvent: anEvent [
+	"Return the roassal shape for the event provided as argument"
+	^ roassalCanvas shapesWithActionForPositionInPixels: (self relativePositionFor: anEvent)
 ]
 
 { #category : 'events - processing' }

--- a/src/Roassal/RSGroup.extension.st
+++ b/src/Roassal/RSGroup.extension.st
@@ -1,6 +1,16 @@
 Extension { #name : 'RSGroup' }
 
 { #category : '*Roassal' }
+RSGroup >> entriesAtPoint: position [
+	| result |
+	result := OrderedCollection new.
+	self reverseDo: [ :entry |
+		entry addEntriesIn: result position: position.
+	].
+	^ result
+]
+
+{ #category : '*Roassal' }
 RSGroup >> entriesAtRectangle: aRectangle [
 	^ self select: [ :each | each encompassingRectangle intersects: aRectangle ]
 ]

--- a/src/Roassal/RSShape.class.st
+++ b/src/Roassal/RSShape.class.st
@@ -173,8 +173,7 @@ RSShape >> announce: anEventOrAnEventClassOrABlock [
 	announcer ifNil: [ ^ self ].
 	theEventToSend := anEventOrAnEventClassOrABlock value asAnnouncement.
 	theEventToSend canvas ifNil: [ theEventToSend canvas: self canvas ].
-
-	theEventToSend shape: self.
+	theEventToSend shape ifNil: [ theEventToSend shape: self ].
 	announcer announce: theEventToSend
 ]
 

--- a/src/Roassal/SequenceableCollection.extension.st
+++ b/src/Roassal/SequenceableCollection.extension.st
@@ -8,6 +8,16 @@ SequenceableCollection >> argmax [
 ]
 
 { #category : '*Roassal' }
+SequenceableCollection >> hasSameObjects: otherCollection [
+	| size |
+	(size := self size) = otherCollection size ifFalse: [^ false].
+	1 to: size do:
+		[:index |
+		(self at: index) == (otherCollection at: index) ifFalse: [^ false]].
+	^ true
+]
+
+{ #category : '*Roassal' }
 SequenceableCollection >> max: aSelectorOrOneArgBlock [
 	^ (self collect: aSelectorOrOneArgBlock) max
 ]


### PR DESCRIPTION
This is a change done by Milton and me 2 years ago in a remote pair-programming session, to improve the event processor of Roassal. I don't remember why we didn't merge it, nor create a PR... but I am recovering the change via cherrypicking as it is not possible to create a github PR since migration from object-profile/Roassal3 repo to this pharo-graphics/Roassal resulted in disconnected histories.

Original commit: https://github.com/pharo-graphics/Roassal/commit/273c1942099fa31ba4a5b3976796482da48a4dd4