### PR TITLE
Remove dead code

### DIFF
--- a/src/Roassal-Chart/RSAbstractChart.class.st
+++ b/src/Roassal-Chart/RSAbstractChart.class.st
@@ -247,12 +247,6 @@ RSAbstractChart >> inspectorCanvas: aBuilder [
 		yourself
 ]
 
-{ #category : 'inspector' }
-RSAbstractChart >> inspectorCanvasContext: aContext [
-
-  aContext withoutEvaluator
-]
-
 { #category : 'accessing - extension' }
 RSAbstractChart >> maxChartValueX [
 	"the maximum value displayed on the x-axis of the chart"

--- a/src/Roassal-Inspector/RSCanvas.extension.st
+++ b/src/Roassal-Inspector/RSCanvas.extension.st
@@ -17,12 +17,6 @@ RSCanvas >> inspectorCanvas: aBuilder [
 ]
 
 { #category : '*Roassal-Inspector' }
-RSCanvas >> inspectorCanvasContext: aContext [
-
-	aContext withoutEvaluator
-]
-
-{ #category : '*Roassal-Inspector' }
 RSCanvas >> inspectorContext [
 	"Return the context used in the canvas. The inspector context contains all the registration that is added to a canvas per default, when being used in the GTInspector. Registrations can be easily diseabled, for example, in case one wishes to disable the opening of a new inspector pane by clicking on an object using:
 ```


### PR DESCRIPTION
Move extensions to proper places:
 - to the defining classes if possible
 - to the user if (and very clear) there is only one
 - close to other similar extensions if possible

Related to https://github.com/pharo-project/pharo/pull/19150